### PR TITLE
RLID Package

### DIFF
--- a/pkg/rlid/errors.go
+++ b/pkg/rlid/errors.go
@@ -14,4 +14,7 @@ var (
 
 	// Returned when unmarshaling RLIDs in strict mode if the string contains bad chars
 	ErrInvalidCharacters = errors.New("invalid characters: cannot decode the id from string")
+
+	// Returned when using the sql.Scanner interface if the type is incorrect.
+	ErrScanValue = errors.New("source value must be either string or byte slice")
 )


### PR DESCRIPTION
### Scope of changes

An RLID is a totally ordered, 80 byte data structure that encodes both time and a monotonically increasing sequence number. It is inspired by ULID and Snowflake IDs. The purpose of this package is to assign totally ordered IDs to events in the Ensign system.

Fixes SC-9291

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

The benchmarks for the current implementation are as follows:

```
goos: darwin
goarch: arm64
pkg: github.com/rotationalio/ensign/pkg/rlid
BenchmarkMake-10           	23952832	        42.12 ns/op	 237.44 MB/s	       0 B/op	       0 allocs/op
BenchmarkNow-10            	28846992	        41.53 ns/op	 192.62 MB/s	       0 B/op	       0 allocs/op
BenchmarkTimestamp-10      	1000000000	         0.3154 ns/op	25367.04 MB/s	       0 B/op	       0 allocs/op
BenchmarkTime-10           	1000000000	         0.3111 ns/op	25712.95 MB/s	       0 B/op	       0 allocs/op
BenchmarkSetTime-10        	1000000000	         0.3110 ns/op	25724.50 MB/s	       0 B/op	       0 allocs/op
BenchmarkSequence-10       	1000000000	         0.3108 ns/op	12871.14 MB/s	       0 B/op	       0 allocs/op
BenchmarkSetSequence-10    	1000000000	         0.3111 ns/op	12858.91 MB/s	       0 B/op	       0 allocs/op
```

Given these benchmarks it seems like it is only possible to generate 23k ID

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.