### PR TITLE
GCP Logging Hook

### DIFF
--- a/pkg/ensign/server.go
+++ b/pkg/ensign/server.go
@@ -14,6 +14,7 @@ import (
 	api "github.com/rotationalio/ensign/pkg/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/config"
 	"github.com/rotationalio/ensign/pkg/ensign/o11y"
+	"github.com/rotationalio/ensign/pkg/utils/logger"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
@@ -21,9 +22,14 @@ import (
 )
 
 func init() {
-	// Initialize zerolog for server-side process logging
-	zerolog.TimeFieldFormat = time.RFC3339Nano
-	log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
+	// Initializes zerolog with our default logging requirements
+	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.TimestampFieldName = logger.GCPFieldKeyTime
+	zerolog.MessageFieldName = logger.GCPFieldKeyMsg
+
+	// Add the severity hook for GCP logging
+	var gcpHook logger.SeverityHook
+	log.Logger = zerolog.New(os.Stdout).Hook(gcpHook).With().Timestamp().Logger()
 }
 
 // An Ensign server implements the Ensign service as defined by the wire protocol.

--- a/pkg/quarterdeck/quarterdeck.go
+++ b/pkg/quarterdeck/quarterdeck.go
@@ -13,15 +13,20 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rotationalio/ensign/pkg"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/config"
+	"github.com/rotationalio/ensign/pkg/utils/logger"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
 func init() {
-	// Initialize zerolog with our default logging requirements
+	// Initializes zerolog with our default logging requirements
 	zerolog.TimeFieldFormat = time.RFC3339
-	zerolog.TimestampFieldName = "time"
-	zerolog.MessageFieldName = "message"
+	zerolog.TimestampFieldName = logger.GCPFieldKeyTime
+	zerolog.MessageFieldName = logger.GCPFieldKeyMsg
+
+	// Add the severity hook for GCP logging
+	var gcpHook logger.SeverityHook
+	log.Logger = zerolog.New(os.Stdout).Hook(gcpHook).With().Timestamp().Logger()
 }
 
 func New(conf config.Config) (s *Server, err error) {

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rotationalio/ensign/pkg"
 	"github.com/rotationalio/ensign/pkg/tenant/config"
+	"github.com/rotationalio/ensign/pkg/utils/logger"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -20,8 +21,12 @@ import (
 func init() {
 	// Initializes zerolog with our default logging requirements
 	zerolog.TimeFieldFormat = time.RFC3339
-	zerolog.TimestampFieldName = "time"
-	zerolog.MessageFieldName = "message"
+	zerolog.TimestampFieldName = logger.GCPFieldKeyTime
+	zerolog.MessageFieldName = logger.GCPFieldKeyMsg
+
+	// Add the severity hook for GCP logging
+	var gcpHook logger.SeverityHook
+	log.Logger = zerolog.New(os.Stdout).Hook(gcpHook).With().Timestamp().Logger()
 }
 
 func New(conf config.Config) (s *Server, err error) {

--- a/pkg/utils/logger/logger.go
+++ b/pkg/utils/logger/logger.go
@@ -1,0 +1,40 @@
+package logger
+
+import "github.com/rs/zerolog"
+
+type severityGCP string
+
+const (
+	GCPAlertLevel    severityGCP = "ALERT"
+	GCPCriticalLevel severityGCP = "CRITICAL"
+	GCPErrorLevel    severityGCP = "ERROR"
+	GCPWarningLevel  severityGCP = "WARNING"
+	GCPInfoLevel     severityGCP = "INFO"
+	GCPDebugLevel    severityGCP = "DEBUG"
+
+	GCPFieldKeySeverity = "severity"
+	GCPFieldKeyMsg      = "message"
+	GCPFieldKeyTime     = "time"
+)
+
+var (
+	zerologToGCPLevel = map[zerolog.Level]severityGCP{
+		zerolog.PanicLevel: GCPAlertLevel,
+		zerolog.FatalLevel: GCPCriticalLevel,
+		zerolog.ErrorLevel: GCPErrorLevel,
+		zerolog.WarnLevel:  GCPWarningLevel,
+		zerolog.InfoLevel:  GCPInfoLevel,
+		zerolog.DebugLevel: GCPDebugLevel,
+		zerolog.TraceLevel: GCPDebugLevel,
+	}
+)
+
+// SeverityHook adds GCP severity levels to zerolog output log messages.
+type SeverityHook struct{}
+
+// Run implements the zerolog.Hook interface.
+func (h SeverityHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+	if level != zerolog.NoLevel {
+		e.Str(GCPFieldKeySeverity, string(zerologToGCPLevel[level]))
+	}
+}

--- a/pkg/utils/logger/logger_test.go
+++ b/pkg/utils/logger/logger_test.go
@@ -1,0 +1,121 @@
+package logger_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rotationalio/ensign/pkg/utils/logger"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+type testWriter struct {
+	lastLog map[string]interface{}
+	levels  map[zerolog.Level]uint16
+}
+
+func (w *testWriter) WriteLevel(level zerolog.Level, p []byte) (n int, err error) {
+	if w.levels == nil {
+		w.levels = make(map[zerolog.Level]uint16)
+	}
+	w.levels[level]++
+	return w.Write(p)
+}
+
+func (w *testWriter) Write(p []byte) (n int, err error) {
+	if err = json.Unmarshal(p, &w.lastLog); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func TestSeverityHook(t *testing.T) {
+	// Initialize zerolog with GCP logging requirements
+	zerolog.TimeFieldFormat = time.RFC3339
+	zerolog.TimestampFieldName = logger.GCPFieldKeyTime
+	zerolog.MessageFieldName = logger.GCPFieldKeyMsg
+
+	// Test writer
+	tw := &testWriter{}
+
+	// Add the severity hook for GCP logging
+	var gcpHook logger.SeverityHook
+	log.Logger = zerolog.New(tw).Hook(gcpHook).With().Timestamp().Logger()
+
+	log.Trace().Msg("just a trace")
+	require.Equal(t, uint16(1), tw.levels[zerolog.TraceLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "DEBUG", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "just a trace", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+
+	log.Debug().Msg("is it on?")
+	require.Equal(t, uint16(1), tw.levels[zerolog.DebugLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "DEBUG", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "is it on?", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+
+	log.Info().Str("extra", "foo").Msg("my name is bob")
+	require.Equal(t, uint16(1), tw.levels[zerolog.InfoLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "INFO", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "my name is bob", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, "extra")
+	require.Equal(t, "foo", tw.lastLog["extra"])
+
+	log.Warn().Msg("don't run with scissors")
+	require.Equal(t, uint16(1), tw.levels[zerolog.WarnLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "WARNING", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "don't run with scissors", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+
+	log.Error().Err(errors.New("bad things")).Msg("oops")
+	require.Equal(t, uint16(1), tw.levels[zerolog.ErrorLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "ERROR", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "oops", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, "error")
+	require.Equal(t, "bad things", tw.lastLog["error"])
+
+	// Must use WithLevel or the program will exit and the test will fail.
+	log.WithLevel(zerolog.FatalLevel).Err(errors.New("murder")).Msg("dying")
+	require.Equal(t, uint16(1), tw.levels[zerolog.FatalLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "CRITICAL", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "dying", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, "error")
+	require.Equal(t, "murder", tw.lastLog["error"])
+
+	require.Panics(t, func() {
+		log.Panic().Err(errors.New("run away!")).Msg("squeeeee!!!")
+	})
+	require.Equal(t, uint16(1), tw.levels[zerolog.PanicLevel])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeySeverity)
+	require.Equal(t, "ALERT", tw.lastLog[logger.GCPFieldKeySeverity])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyMsg)
+	require.Equal(t, "squeeeee!!!", tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, logger.GCPFieldKeyTime)
+	require.NotEmpty(t, tw.lastLog[logger.GCPFieldKeyMsg])
+	require.Contains(t, tw.lastLog, "error")
+	require.Equal(t, "run away!", tw.lastLog["error"])
+}

--- a/pkg/utils/logger/middleware.go
+++ b/pkg/utils/logger/middleware.go
@@ -1,0 +1,54 @@
+package logger
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// GinLogger returns a new Gin middleware that performs logging for our JSON APIs using
+// zerolog rather than the default Gin logger which is a standard HTTP logger. Provide
+// the server name (e.g. adminAPI or BFF) to help us parse the logs.
+// NOTE: we previously used github.com/dn365/gin-zerolog but wanted more customization.
+func GinLogger(server string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Before request
+		started := time.Now()
+		path := c.Request.URL.Path
+		if c.Request.URL.RawQuery != "" {
+			path = path + "?" + c.Request.URL.RawQuery
+		}
+
+		// Handle the request
+		c.Next()
+
+		// After request
+		status := c.Writer.Status()
+		logctx := log.With().
+			Str("path", path).
+			Str("ser_name", server).
+			Str("method", c.Request.Method).
+			Dur("resp_time", time.Since(started)).
+			Int("resp_bytes", c.Writer.Size()).
+			Int("status", status).
+			Str("client_ip", c.ClientIP()).
+			Logger()
+
+		// This field requires us to append errors to the Gin context before a 500
+		msg := c.Errors.String()
+		if msg == "" {
+			msg = fmt.Sprintf("%s %s %s %d", server, c.Request.Method, c.Request.URL.Path, status)
+		}
+
+		switch {
+		case status >= 400 && status < 500:
+			logctx.Warn().Msg(msg)
+		case status >= 500:
+			logctx.Error().Msg(msg)
+		default:
+			logctx.Info().Msg(msg)
+		}
+	}
+}


### PR DESCRIPTION
### Scope of changes

Adds GCP-specific logging hooks to ensure that we will get alerts from Ensign services.

Fixes SC-8782

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Did I configure all the places where we're setting up logging?

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [x]  I have updated the dependencies list
- [x]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] It appears that all logging `init` functions are modified 