### PR TITLE
Attempt to address deprecation warnings

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -21,7 +21,7 @@ jobs:
         id: vars
         run: |
           echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta
@@ -94,7 +94,7 @@ jobs:
         id: vars
         run: |
           echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta
@@ -167,7 +167,7 @@ jobs:
         id: vars
         run: |
           echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta
@@ -240,7 +240,7 @@ jobs:
         id: vars
         run: |
           echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "revision=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Environment
         id: vars
         run: |
-          echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
-          echo "::set-output name=revision::$(git rev-parse --short HEAD)"
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta
@@ -93,8 +93,8 @@ jobs:
       - name: Setup Environment
         id: vars
         run: |
-          echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
-          echo "::set-output name=revision::$(git rev-parse --short HEAD)"
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta
@@ -166,8 +166,8 @@ jobs:
       - name: Setup Environment
         id: vars
         run: |
-          echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
-          echo "::set-output name=revision::$(git rev-parse --short HEAD)"
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta
@@ -239,8 +239,8 @@ jobs:
       - name: Setup Environment
         id: vars
         run: |
-          echo "::set-output name=tag::${GITHUB_REF#refs/*/}"
-          echo "::set-output name=revision::$(git rev-parse --short HEAD)"
+          echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+          echo "revision::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Docker Metadata
         id: meta

--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -1,7 +1,6 @@
 package tenant
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"


### PR DESCRIPTION
### Scope of changes

This PR attempts to address the deprecation warnings related to the set-output workflow in Github Actions, which I believe Ensign is using to determine the commit and branch is being shown in the front end. I've used the instructions posted by Github [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Fixes SC-10218; though in order to see if it actually works, I'll have to open this PR first!

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [x] other (resolve deprecation warning in GH Action)

### Acceptance criteria

If this works, the deprecations warnings in GH Actions should go away!

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.