### PR TITLE
TenantMemberCreate and MemberCreate server-side handlers and tests

### DIFF
--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -12,6 +12,80 @@ import (
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 )
 
+func (suite *tenantTestSuite) TestTenantMemberCreate() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	defer cancel()
+
+	// Connect to a mock trtl database
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	// Call the OnPut method and return a PutReply
+	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
+		return &pb.PutReply{}, nil
+	}
+
+	// Should return an error if the member name does not exist
+	_, err := suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Role: "Admin"})
+	suite.requireError(err, http.StatusBadRequest, "member name is required", "expected error when member name does not exist")
+
+	// Should return an error if the member role does not exist.
+	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Name: "member-example"})
+	suite.requireError(err, http.StatusBadRequest, "member role is required", "expected error when member role does not exist")
+
+	tenant := &api.Tenant{
+		ID: ulid.Make().String(),
+	}
+
+	// Create a member test fixture
+	req := &api.Member{
+		Name: "member-example",
+		Role: "Admin",
+	}
+
+	member, err := suite.client.TenantMemberCreate(ctx, tenant.ID, req)
+	require.NoError(err, "could not add member")
+	require.Equal(req.Name, member.Name, "member name should match")
+	require.Equal(req.Role, member.Role, "member role should match")
+}
+
+func (suite *tenantTestSuite) TestMemberCreate() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	defer cancel()
+
+	// Connect to a mock trtl database
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	// Call the OnPut method and return a PutReply
+	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
+		return &pb.PutReply{}, nil
+	}
+
+	// Should return an error if the member name does not exist
+	_, err := suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Role: "Admin"})
+	suite.requireError(err, http.StatusBadRequest, "member name is required", "expected error when member name does not exist")
+
+	// Should return an error if the member role does not exist.
+	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Name: "member-example"})
+	suite.requireError(err, http.StatusBadRequest, "member role is required", "expected error when member role does not exist")
+
+	// Create a member test fixture
+	req := &api.Member{
+		Name: "member-example",
+		Role: "Admin",
+	}
+
+	member, err := suite.client.MemberCreate(ctx, req)
+	require.NoError(err, "could not add member")
+	require.Equal(req.Name, member.Name, "expected memeber name to match")
+	require.Equal(req.Role, member.Role, "expected member role to match")
+}
+
 func (suite *tenantTestSuite) TestMemberDetail() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
### Scope of changes

Adds server-side handlers for TenantMemberCreate and MemberCreate to the Tenant API. This will allow new members to be added to the database.

Fixes SC-10404

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [x] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.