### PR TITLE
TopicDetail, TopicUpdate, and TopicDelete handlers

### DIFF
--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -217,6 +217,7 @@ func (suite *tenantTestSuite) TestMemberDelete() {
 	err = suite.client.MemberDelete(ctx, memberID)
 	require.NoError(err, "could not delete member")
 
+	// Should return an error if the member ID is parsed but not found.
 	trtl.OnDelete = func(ctx context.Context, dr *pb.DeleteRequest) (*pb.DeleteReply, error) {
 		return nil, errors.New("key not found")
 	}

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -49,17 +49,17 @@ func (s *Server) TopicDetail(c *gin.Context) {
 
 	// Get the topic ID from the URL and return a 400 response
 	// if the topic does not exist.
+	//
+	// Route: /topic/:topicID
 	var topicID ulid.ULID
 	if topicID, err = ulid.Parse(c.Param("topicID")); err != nil {
 		log.Error().Err(err).Msg("could not parse topic ulid")
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic id"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic ulid"))
 		return
 	}
 
 	// Get the specified topic from the database and return a 404 response
 	// if it cannot be retrieved.
-	//
-	// Route: /topic/:topicID
 	var topic *db.Topic
 	if topic, err = db.RetrieveTopic(c.Request.Context(), topicID); err != nil {
 		log.Error().Err(err).Str("topicID", topicID.String()).Msg("could not retrieve topic")
@@ -90,7 +90,7 @@ func (s *Server) TopicUpdate(c *gin.Context) {
 	var topicID ulid.ULID
 	if topicID, err = ulid.Parse(c.Param("topicID")); err != nil {
 		log.Error().Err(err).Msg("could not parse topic ulid")
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic id"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic ulid"))
 		return
 	}
 
@@ -142,7 +142,7 @@ func (s *Server) TopicDelete(c *gin.Context) {
 	var topicID ulid.ULID
 	if topicID, err = ulid.Parse(c.Param("topicID")); err != nil {
 		log.Error().Err(err).Msg("could not parse topic ulid")
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic id"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic ulid"))
 		return
 	}
 

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -4,6 +4,10 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
+	"github.com/rotationalio/ensign/pkg/tenant/db"
+	"github.com/rs/zerolog/log"
 )
 
 func (s *Server) ProjectTopicList(c *gin.Context) {
@@ -31,18 +35,123 @@ func (s *Server) TopicList(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }
 
-func (s *Server) TopicDetail(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "not implemented yet")
-}
-
 func (s *Server) TopicCreate(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }
 
-func (s *Server) TopicUpdate(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "not implemented yet")
+// TopicDetail retrieves a summary detail of a topic with a given ID
+// and returns a 200 OK response.
+func (s *Server) TopicDetail(c *gin.Context) {
+	var (
+		err   error
+		reply *api.Topic
+	)
+
+	// Get the topic ID from the URL and return a 400 response
+	// if the topic does not exist.
+	var topicID ulid.ULID
+	if topicID, err = ulid.Parse(c.Param("topicID")); err != nil {
+		log.Error().Err(err).Msg("could not parse topic ulid")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic id"))
+		return
+	}
+
+	// Get the specified topic from the database and return a 404 response
+	// if it cannot be retrieved.
+	//
+	// Route: /topic/:topicID
+	var topic *db.Topic
+	if topic, err = db.RetrieveTopic(c.Request.Context(), topicID); err != nil {
+		log.Error().Err(err).Str("topicID", topicID.String()).Msg("could not retrieve topic")
+		c.JSON(http.StatusNotFound, api.ErrorResponse("could not retrieve topic"))
+		return
+	}
+
+	reply = &api.Topic{
+		ID:   topic.ID.String(),
+		Name: topic.Name,
+	}
+
+	c.JSON(http.StatusOK, reply)
 }
 
+// TopicUpdate updates the record of a topic with a given ID and
+// returns a 200 OK response.
+//
+// Route: /topic/:topicID
+func (s *Server) TopicUpdate(c *gin.Context) {
+	var (
+		err   error
+		topic *api.Topic
+	)
+
+	// Get the topic ID from the URL and return a 400 response if
+	// the topic ID is not a ULID.
+	var topicID ulid.ULID
+	if topicID, err = ulid.Parse(c.Param("topicID")); err != nil {
+		log.Error().Err(err).Msg("could not parse topic ulid")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic id"))
+		return
+	}
+
+	// Bind the user request with JSON and return a 400 response if
+	// binding is not successful.
+	if err = c.BindJSON(&topic); err != nil {
+		log.Warn().Err(err).Msg("could not parse topic update request")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not bind user request"))
+		return
+	}
+
+	// Verify the topic name exists and return a 400 response if it doesn't.
+	if topic.Name == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("topic name is required"))
+		return
+	}
+
+	// Get the specified topic from the database and return a 404 response if
+	// it cannot be retrieved.
+	var t *db.Topic
+	if t, err = db.RetrieveTopic(c.Request.Context(), topicID); err != nil {
+		log.Error().Err(err).Str("topicID", topicID.String()).Msg("could not retrieve topic")
+		c.JSON(http.StatusNotFound, api.ErrorResponse("topic not found"))
+		return
+	}
+
+	// Update topic in the database and return a 500 response if the topic
+	// record cannot be updated.
+	if err = db.UpdateTopic(c.Request.Context(), t); err != nil {
+		log.Error().Err(err).Str("topicID", topicID.String()).Msg("could not save topic")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not update topic"))
+		return
+	}
+
+	c.JSON(http.StatusOK, topic)
+}
+
+// TopicDelete deletes a topic from a user's request with a given ID
+// and returns a 200 OK response instead of an error response.
+//
+// Route: /topic/:topicID
 func (s *Server) TopicDelete(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "not implemented yet")
+	var (
+		err error
+	)
+
+	// Get the topic ID from the URL and return a 400 response
+	// if the topic does not exist.
+	var topicID ulid.ULID
+	if topicID, err = ulid.Parse(c.Param("topicID")); err != nil {
+		log.Error().Err(err).Msg("could not parse topic ulid")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse topic id"))
+		return
+	}
+
+	// Delete the topic and return a 404 response if it cannot be removed.
+	if err = db.DeleteTopic(c.Request.Context(), topicID); err != nil {
+		log.Error().Err(err).Str("topicID", topicID.String()).Msg("could not delete topic")
+		c.JSON(http.StatusNotFound, api.ErrorResponse("could not delete topic"))
+		return
+	}
+
+	c.Status(http.StatusOK)
 }

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -1,1 +1,159 @@
 package tenant_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
+	"github.com/rotationalio/ensign/pkg/tenant/db"
+	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
+)
+
+func (suite *tenantTestSuite) TestTopicDetail() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	topic := &db.Topic{
+		ProjectID: ulid.MustParse("01GNA91N6WMCWNG9MVSK47ZS88"),
+		ID:        ulid.MustParse("01GNA926JCTKDH3VZBTJM8MAF6"),
+		Name:      "topic-example",
+	}
+
+	defer cancel()
+
+	// Connect to mock trtl database
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	// Marshal the data with msgpack.
+	data, err := topic.MarshalValue()
+	require.NoError(err, "could not marshal the toopic")
+
+	// Unmarshal the data with msgpack.
+	other := &db.Topic{}
+	err = other.UnmarshalValue(data)
+	require.NoError(err, "could not unmarshal the topic")
+
+	// Call OnGet method and return a GetReply.
+	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
+		return &pb.GetReply{
+			Value: data,
+		}, nil
+	}
+
+	// Should return an error if the topic does not exist.
+	_, err = suite.client.TopicDetail(ctx, "invalid")
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic id", "expected error when topic does not exist")
+
+	// Create a topic test fixture.
+	req := &api.Topic{
+		ID:   "01GNA926JCTKDH3VZBTJM8MAF6",
+		Name: "topic-example",
+	}
+
+	rep, err := suite.client.TopicDetail(ctx, req.ID)
+	require.NoError(err, "could not retrieve topic")
+	require.Equal(req.ID, rep.ID, "expected topic ID to match")
+	require.Equal(req.Name, rep.Name, "expected topic name to match")
+
+	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
+		return nil, errors.New("key not found")
+	}
+
+	_, err = suite.client.TopicDetail(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusNotFound, "could not retrieve topic", "expected error when topic ID is not found")
+}
+
+func (suite *tenantTestSuite) TestTopicUpdate() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	topic := &db.Topic{
+		ProjectID: ulid.MustParse("01GNA91N6WMCWNG9MVSK47ZS88"),
+		ID:        ulid.MustParse("01GNA926JCTKDH3VZBTJM8MAF6"),
+		Name:      "topic-example",
+	}
+
+	defer cancel()
+
+	// Connect to mock trtl database.
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	// Marshal the data with msgpack.
+	data, err := topic.MarshalValue()
+	require.NoError(err, "could not marshal the data")
+
+	other := &db.Topic{}
+	err = other.UnmarshalValue(data)
+	require.NoError(err, "could not unmarshal the data")
+
+	// Call the OnGet method and return the test data.
+	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
+		return &pb.GetReply{
+			Value: data,
+		}, nil
+	}
+
+	// Should return an error if the topic does not exist.
+	_, err = suite.client.TopicDetail(ctx, "invalid")
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic id", "expected error when topic does not exist")
+
+	// Call the OnPut method and return a PutReply.
+	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
+		return &pb.PutReply{}, nil
+	}
+
+	// Should return an error if the topic name does not exist.
+	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6"})
+	suite.requireError(err, http.StatusBadRequest, "topic name is required", "expected error when topic name does not exist")
+
+	req := &api.Topic{
+		ID:   "01GNA926JCTKDH3VZBTJM8MAF6",
+		Name: "topic-example",
+	}
+
+	rep, err := suite.client.TopicUpdate(ctx, req)
+	require.NoError(err, "could not update topic")
+	require.NotEqual(req.ID, "", "topic id should not match")
+	require.Equal(req.Name, rep.Name, "expected topic name to match")
+
+	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
+		return nil, errors.New("key not found")
+	}
+
+	_, err = suite.client.TopicDetail(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusNotFound, "could not retrieve topic", "expected error when topic ID is not found")
+}
+
+func (suite *tenantTestSuite) TestTopicDelete() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	topicID := "01GNA926JCTKDH3VZBTJM8MAF6"
+
+	defer cancel()
+
+	// Connect to mock trtl database.
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	// Call OnDelete method and return a DeleteReply.
+	trtl.OnDelete = func(ctx context.Context, dr *pb.DeleteRequest) (*pb.DeleteReply, error) {
+		return &pb.DeleteReply{}, nil
+	}
+
+	// Should return an error if the topic does not exist.
+	err := suite.client.TopicDelete(ctx, "invalid")
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic id", "expected error when topic does not exist")
+
+	err = suite.client.TopicDelete(ctx, topicID)
+	require.NoError(err, "could not delete topic")
+
+	trtl.OnDelete = func(ctx context.Context, dr *pb.DeleteRequest) (*pb.DeleteReply, error) {
+		return nil, errors.New("key not found")
+	}
+
+	err = suite.client.TopicDelete(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusNotFound, "could not delete topic", "expected error when topic ID is not found")
+}

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -27,14 +27,14 @@ func (suite *tenantTestSuite) TestTopicDetail() {
 	trtl := db.GetMock()
 	defer trtl.Reset()
 
-	// Marshal the data with msgpack.
+	// Marshal the topic data with msgpack.
 	data, err := topic.MarshalValue()
-	require.NoError(err, "could not marshal the toopic")
+	require.NoError(err, "could not marshal the topic data")
 
-	// Unmarshal the data with msgpack.
+	// Unmarshal the topic data with msgpack.
 	other := &db.Topic{}
 	err = other.UnmarshalValue(data)
-	require.NoError(err, "could not unmarshal the topic")
+	require.NoError(err, "could not unmarshal the topic data")
 
 	// Call OnGet method and return a GetReply.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
@@ -62,6 +62,7 @@ func (suite *tenantTestSuite) TestTopicDetail() {
 		return nil, errors.New("key not found")
 	}
 
+	// Should return an error if the topic ID is parsed but not found.
 	_, err = suite.client.TopicDetail(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
 	suite.requireError(err, http.StatusNotFound, "could not retrieve topic", "expected error when topic ID is not found")
 }
@@ -81,13 +82,14 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 	trtl := db.GetMock()
 	defer trtl.Reset()
 
-	// Marshal the data with msgpack.
+	// Marshal the topic data with msgpack.
 	data, err := topic.MarshalValue()
-	require.NoError(err, "could not marshal the data")
+	require.NoError(err, "could not marshal the topic data")
 
+	// Unmarshal the topic data with msgpack.
 	other := &db.Topic{}
 	err = other.UnmarshalValue(data)
-	require.NoError(err, "could not unmarshal the data")
+	require.NoError(err, "could not unmarshal the topic data")
 
 	// Call the OnGet method and return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
@@ -119,6 +121,7 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 	require.NotEqual(req.ID, "", "topic id should not match")
 	require.Equal(req.Name, rep.Name, "expected topic name to match")
 
+	// Should return an error if the topic ID is parsed but not found.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return nil, errors.New("key not found")
 	}
@@ -150,6 +153,7 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 	err = suite.client.TopicDelete(ctx, topicID)
 	require.NoError(err, "could not delete topic")
 
+	// Should return an error if the topic ID is parsed but not found.
 	trtl.OnDelete = func(ctx context.Context, dr *pb.DeleteRequest) (*pb.DeleteReply, error) {
 		return nil, errors.New("key not found")
 	}

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -45,7 +45,7 @@ func (suite *tenantTestSuite) TestTopicDetail() {
 
 	// Should return an error if the topic does not exist.
 	_, err = suite.client.TopicDetail(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse topic id", "expected error when topic does not exist")
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic ulid", "expected error when topic does not exist")
 
 	// Create a topic test fixture.
 	req := &api.Topic{
@@ -100,7 +100,7 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 
 	// Should return an error if the topic does not exist.
 	_, err = suite.client.TopicDetail(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse topic id", "expected error when topic does not exist")
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic ulid", "expected error when topic does not exist")
 
 	// Call the OnPut method and return a PutReply.
 	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
@@ -148,7 +148,7 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 
 	// Should return an error if the topic does not exist.
 	err := suite.client.TopicDelete(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse topic id", "expected error when topic does not exist")
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic ulid", "expected error when topic does not exist")
 
 	err = suite.client.TopicDelete(ctx, topicID)
 	require.NoError(err, "could not delete topic")


### PR DESCRIPTION
### Scope of changes

Adds server-side handlers for TopicDetail, TopicUpdate, and TopicDelete.

TopicDetail will retrieve a topic record from the database with a given ID.
TopicUpdate will update a topic record in the database with a given ID.
TopicDelete will remove a topic record from the database with a given ID.

The changes are similar to the [members](https://github.com/rotationalio/ensign/blob/main/pkg/tenant/members.go) and [members test](https://github.com/rotationalio/ensign/blob/main/pkg/tenant/members_test.go) files. 

Fixes SC-10410 and SC-10414

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [x] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [x]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.