### PR TITLE
Sc 10406/create handlers

### DIFF
--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -17,7 +17,7 @@ func (s *Server) TenantMemberList(c *gin.Context) {
 // / TenantMemberCreate adds a new tenant member to the database and returns
 // a 201 StatusCreated response.
 //
-// Route: /tenant/:tenantID/member
+// Route: /tenant/:tenantID/members
 func (s *Server) TenantMemberCreate(c *gin.Context) {
 	var (
 		err    error
@@ -105,7 +105,7 @@ func (s *Server) MemberCreate(c *gin.Context) {
 	// Verify that a member id does not exist and return a 400 response if
 	// the member id exists.
 	if member.ID != "" {
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("member is cannot be specified on create"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("member id cannot be specified on create"))
 		return
 	}
 

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -15,6 +15,7 @@ import (
 func (suite *tenantTestSuite) TestTenantMemberCreate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	tenantID := ulid.Make().String()
 
 	defer cancel()
 
@@ -27,13 +28,17 @@ func (suite *tenantTestSuite) TestTenantMemberCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Should return an error if the member id exists.
+	_, err := suite.client.TenantMemberCreate(ctx, tenantID, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member-example", Role: "Admin"})
+	suite.requireError(err, http.StatusBadRequest, "member id cannot be specified on create", "expected error when member id exists")
+
 	// Should return an error if the member name does not exist
-	_, err := suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Role: "Admin"})
-	suite.requireError(err, http.StatusBadRequest, "member name is required", "expected error when member name does not exist")
+	_, err = suite.client.TenantMemberCreate(ctx, tenantID, &api.Member{ID: "", Role: "Admin"})
+	suite.requireError(err, http.StatusBadRequest, "tenant member name is required", "expected error when tenant member name does not exist")
 
 	// Should return an error if the member role does not exist.
-	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Name: "member-example"})
-	suite.requireError(err, http.StatusBadRequest, "member role is required", "expected error when member role does not exist")
+	_, err = suite.client.TenantMemberCreate(ctx, tenantID, &api.Member{ID: "", Name: "member-example"})
+	suite.requireError(err, http.StatusBadRequest, "tenant member role is required", "expected error when tenant member role does not exist")
 
 	tenant := &api.Tenant{
 		ID: ulid.Make().String(),
@@ -66,12 +71,16 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Should return an error is member id exists.
+	_, err := suite.client.MemberCreate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member-example", Role: "Admin"})
+	suite.requireError(err, http.StatusBadRequest, "member id cannot be specified on create", "expected error when member id exists")
+
 	// Should return an error if the member name does not exist
-	_, err := suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Role: "Admin"})
+	_, err = suite.client.MemberCreate(ctx, &api.Member{ID: "", Role: "Admin"})
 	suite.requireError(err, http.StatusBadRequest, "member name is required", "expected error when member name does not exist")
 
 	// Should return an error if the member role does not exist.
-	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: ulid.Make().String(), Name: "member-example"})
+	_, err = suite.client.MemberCreate(ctx, &api.Member{ID: "", Name: "member-example"})
 	suite.requireError(err, http.StatusBadRequest, "member role is required", "expected error when member role does not exist")
 
 	// Create a member test fixture

--- a/pkg/tenant/projects.go
+++ b/pkg/tenant/projects.go
@@ -94,7 +94,7 @@ func (s *Server) ProjectCreate(c *gin.Context) {
 	// Verify that a project ID does not exist and return a 400 response
 	// if the project ID exists.
 	if project.ID != "" {
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("project ID cannot be specified on create"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("project id cannot be specified on create"))
 		return
 	}
 

--- a/pkg/tenant/projects.go
+++ b/pkg/tenant/projects.go
@@ -14,8 +14,46 @@ func (s *Server) TenantProjectList(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }
 
+// TenantProjectCreate adds a new tenant project to the database
+// and returns a 201 StatusCreated response.
+//
+// Route: /tenant/:tenantID/projects
 func (s *Server) TenantProjectCreate(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "not implemented yet")
+	var (
+		err     error
+		project *api.Project
+	)
+
+	// Bind the user request and return a 400 response if binding
+	// is not successful.
+	if err = c.BindJSON(&project); err != nil {
+		log.Warn().Err(err).Msg("could not bind tenant project create request")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not bind request"))
+		return
+	}
+
+	// Verify that a project ID does not exist and return a 400 response
+	// if the project ID exists.
+	if project.ID != "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("project id cannot be specified on create"))
+		return
+	}
+
+	// Verify that a project names has been provided and return a 400 response
+	// if the project name does not exist.
+	if project.Name == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("project name is required"))
+		return
+	}
+
+	// Add project to the database and return a 500 response if it cannot be added.
+	if err = db.CreateProject(c.Request.Context(), &db.Project{Name: project.Name}); err != nil {
+		log.Error().Err(err).Msg("could not create tenant project in the database")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add tenant project"))
+		return
+	}
+
+	c.JSON(http.StatusCreated, project)
 }
 
 func (s *Server) ProjectList(c *gin.Context) {
@@ -35,8 +73,46 @@ func (s *Server) ProjectList(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }
 
+// ProjectCreate adds a new project to the database and returns
+// a 201 StatusCreated response.
+//
+// Route: /project
 func (s *Server) ProjectCreate(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "not implemented yet")
+	var (
+		err     error
+		project *api.Project
+	)
+
+	// Bind the user request and return a 400 response if binding
+	// is not successful.
+	if err = c.BindJSON(&project); err != nil {
+		log.Warn().Err(err).Msg("could not bind project create request")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not bind request"))
+		return
+	}
+
+	// Verify that a project ID does not exist and return a 400 response
+	// if the project ID exists.
+	if project.ID != "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("project ID cannot be specified on create"))
+		return
+	}
+
+	// Verify that a project name has been provided and return a 400 response
+	// if the project name does not exist.
+	if project.Name == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("project name is required"))
+		return
+	}
+
+	// Add project to the database and return a 500 response if not successful.
+	if err = db.CreateProject(c.Request.Context(), &db.Project{Name: project.Name}); err != nil {
+		log.Error().Err(err).Msg("could not create project in database")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add project"))
+		return
+	}
+
+	c.JSON(http.StatusCreated, project)
 }
 
 // ProjectDetail retrieves a summary detail of a project by its

--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -71,7 +71,7 @@ func (s *Server) TenantCreate(c *gin.Context) {
 	// Verify that an environment type has been provided and return a 400 response
 	// if the tenant environment type does not exist.
 	if t.EnvironmentType == "" {
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("environment type is required"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("tenant environment type is required"))
 		return
 	}
 

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -50,6 +50,18 @@ func (suite *tenantTestSuite) TestTenantCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Should return an error if tenant id exists.
+	_, err := suite.client.TenantCreate(ctx, &api.Tenant{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "tenant01", EnvironmentType: "prod"})
+	suite.requireError(err, http.StatusBadRequest, "tenant id cannot be specified on create", "expected error when tenant id exists")
+
+	// Should return an error if tenant name does not exist.
+	_, err = suite.client.TenantCreate(ctx, &api.Tenant{ID: "", Name: "", EnvironmentType: "prod"})
+	suite.requireError(err, http.StatusBadRequest, "tenant name is required", "expected error when tenant name does not exist")
+
+	// Should return an error if tenant environment type does not exist.
+	_, err = suite.client.TenantCreate(ctx, &api.Tenant{ID: "", Name: "tenant01", EnvironmentType: ""})
+	suite.requireError(err, http.StatusBadRequest, "tenant environment type is required", "expected error when tenant environment type does not exist")
+
 	// Create a tenant test fixture
 	req := &api.Tenant{
 		Name:            "tenant01",
@@ -59,7 +71,7 @@ func (suite *tenantTestSuite) TestTenantCreate() {
 	tenant, err := suite.client.TenantCreate(ctx, req)
 	require.NoError(err, "could not add tenant")
 	require.Equal(req.Name, tenant.Name, "tenant name should match")
-	require.Equal(req.EnvironmentType, tenant.EnvironmentType, "tenant id should match")
+	require.Equal(req.EnvironmentType, tenant.EnvironmentType, "tenant environment type should match")
 }
 
 func (suite *tenantTestSuite) TestTenantDetail() {

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -14,8 +14,46 @@ func (s *Server) ProjectTopicList(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }
 
+// ProjectTopicCreate adds a new project topic to the database
+// and returns a 201 StatusCreated response.
+//
+// Route: /projects/:projectID/topics
 func (s *Server) ProjectTopicCreate(c *gin.Context) {
-	c.JSON(http.StatusNotImplemented, "not implemented yet")
+	var (
+		err   error
+		topic *api.Topic
+	)
+
+	// Bind the user request with JSON and return a 400 response
+	// if binding is not successful.
+	if err = c.BindJSON(&topic); err != nil {
+		log.Warn().Err(err).Msg("could not bind project topic create request")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not bind request"))
+		return
+	}
+
+	// Verify that a topic ID does not exist and return a 400 response
+	// if the topic ID exists.
+	if topic.ID != "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("topic ID cannot be specified on create"))
+		return
+	}
+
+	// Verify that a topic name has been provided and return a 400 response
+	// if the topic name does not exist.
+	if topic.Name == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("topic name is required"))
+		return
+	}
+
+	// Add topic to the database and return a 500 response if not successful.
+	if err = db.CreateTopic(c.Request.Context(), &db.Topic{Name: topic.Name}); err != nil {
+		log.Error().Err(err).Msg("could not create project topic in the database")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add project topic"))
+		return
+	}
+
+	c.JSON(http.StatusCreated, topic)
 }
 
 func (s *Server) TopicList(c *gin.Context) {

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -35,7 +35,7 @@ func (s *Server) ProjectTopicCreate(c *gin.Context) {
 	// Verify that a topic ID does not exist and return a 400 response
 	// if the topic ID exists.
 	if topic.ID != "" {
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("topic ID cannot be specified on create"))
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("topic id cannot be specified on create"))
 		return
 	}
 

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -111,6 +111,7 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6"})
 	suite.requireError(err, http.StatusBadRequest, "topic name is required", "expected error when topic name does not exist")
 
+	// Create a topic test fixture.
 	req := &api.Topic{
 		ID:   "01GNA926JCTKDH3VZBTJM8MAF6",
 		Name: "topic-example",
@@ -160,4 +161,37 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 
 	err = suite.client.TopicDelete(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
 	suite.requireError(err, http.StatusNotFound, "could not delete topic", "expected error when topic ID is not found")
+}
+
+func (suite *tenantTestSuite) TestProjectTopicCreate() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	projectID := ulid.Make().String()
+
+	defer cancel()
+
+	// Connect to mock trtl database.
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	// Call OnPut method and return a PutReply.
+	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
+		return &pb.PutReply{}, nil
+	}
+
+	// Should return an error if topic id exists.
+	_, err := suite.client.ProjectTopicCreate(ctx, projectID, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6", Name: "topic-example"})
+	suite.requireError(err, http.StatusBadRequest, "topic id cannot be specified on create", "expected error when topic id exists")
+
+	// Should return an error if topic name does not exist.
+	_, err = suite.client.ProjectTopicCreate(ctx, projectID, &api.Topic{ID: "", Name: ""})
+	suite.requireError(err, http.StatusBadRequest, "topic name is required", "expected error when topic name does not exist")
+
+	req := &api.Topic{
+		Name: "topic-example",
+	}
+
+	topic, err := suite.client.ProjectTopicCreate(ctx, projectID, req)
+	require.NoError(err, "could not add topic")
+	require.Equal(req.Name, topic.Name, "expected topic name to match")
 }


### PR DESCRIPTION
### Scope of changes

Adds create handlers to the Tenant API for the projects and topics resources. `TenantProjectCreate` adds a new project to a tenant while `ProjectCreate` adds a new project that's not assigned to a tenant.

Fixes SC-10406

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.