### PR TITLE
Integrate tenant authentication

### DIFF
--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -36,6 +36,7 @@ services:
     init: true
     depends_on:
       - trtl
+      - quarterdeck
     ports:
       - 8080:8080
     environment:
@@ -45,6 +46,10 @@ services:
       - TENANT_LOG_LEVEL=info
       - TENANT_CONSOLE_LOG=true
       - TENANT_ALLOW_ORIGINS=http://localhost:3000
+      - TENANT_AUTH_KEYS_URL=http://quarterdeck:8088/.well-known/jwks.json
+      - TENANT_AUTH_AUDIENCE=http://localhost:3000
+      - TENANT_AUTH_ISSUER=http://localhost:8088
+      - TENANT_AUTH_COOKIE_DOMAIN=localhost
       - TENANT_DATABASE_URL=trtl://trtl:4436
       - TENANT_DATABASE_INSECURE=true
       - TENANT_SENDGRID_API_KEY

--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -31,6 +31,10 @@ func (s *Server) APIKeyList(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }
 
+func (s *Server) APIKeyCreate(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, "not implemented yet")
+}
+
 func (s *Server) APIKeyDetail(c *gin.Context) {
 	c.JSON(http.StatusNotImplemented, "not implemented yet")
 }

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -1,0 +1,26 @@
+package tenant
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	middleware "github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
+	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
+	"github.com/rs/zerolog/log"
+)
+
+// Set the maximum age of login protection cookies.
+const doubleCookiesMaxAge = time.Minute * 10
+
+// ProtectLogin prepares the front-end for login by setting the double cookie
+// tokens for CSRF protection.
+func (s *Server) ProtectLogin(c *gin.Context) {
+	expiresAt := time.Now().Add(doubleCookiesMaxAge)
+	if err := middleware.SetDoubleCookieToken(c, s.conf.Auth.CookieDomain, expiresAt); err != nil {
+		log.Error().Err(err).Msg("could not set cookies")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not set cookies"))
+		return
+	}
+	c.JSON(http.StatusOK, &api.Reply{Success: true})
+}

--- a/pkg/tenant/config/config.go
+++ b/pkg/tenant/config/config.go
@@ -24,10 +24,19 @@ type Config struct {
 	LogLevel     logger.LevelDecoder `split_words:"true" default:"info"`                  // $TENANT_LOG_LEVEL
 	ConsoleLog   bool                `split_words:"true" default:"false"`                 // $TENANT_CONSOLE_LOG
 	AllowOrigins []string            `split_words:"true" default:"http://localhost:3000"` // $TENANT_ALLOW_ORIGINS
+	Auth         AuthConfig          `split_words:"true"`
 	Database     DatabaseConfig      `split_words:"true"`
 	SendGrid     SendGridConfig      `split_words:"false"`
 	Sentry       sentry.Config
 	processed    bool // set when the config is properly procesesed from the environment
+}
+
+// Configures the authentication and authorization for the Tenant API.
+type AuthConfig struct {
+	KeysURL      string `split_words:"true"`
+	Audience     string `split_words:"true"`
+	Issuer       string `split_words:"true"`
+	CookieDomain string `split_words:"true"`
 }
 
 // Configures the connection to trtl for replicated data storage.
@@ -102,6 +111,10 @@ func (c Config) Validate() (err error) {
 		return err
 	}
 
+	if err = c.Auth.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -115,6 +128,11 @@ func (c Config) AllowAllOrigins() bool {
 		return true
 	}
 	return false
+}
+
+func (c AuthConfig) Validate() error {
+	// TODO: Validate the keys URL if provided
+	return nil
 }
 
 // If not insecure, the cert and pool paths are required.

--- a/pkg/tenant/config/config_test.go
+++ b/pkg/tenant/config/config_test.go
@@ -20,6 +20,10 @@ var testEnv = map[string]string{
 	"TENANT_LOG_LEVEL":                "error",
 	"TENANT_CONSOLE_LOG":              "true",
 	"TENANT_ALLOW_ORIGINS":            "http://localhost:8888,http://localhost:8080",
+	"TENANT_AUTH_KEYS_URL":            "http://localhost:8080/.well-known/jwks.json",
+	"TENANT_AUTH_AUDIENCE":            "audience",
+	"TENANT_AUTH_ISSUER":              "issuer",
+	"TENANT_AUTH_COOKIE_DOMAIN":       "localhost",
 	"TENANT_DATABASE_URL":             "trtl://localhost:4436",
 	"TENANT_DATABASE_INSECURE":        "true",
 	"TENANT_DATABASE_CERT_PATH":       "path/to/certs.pem",
@@ -64,6 +68,10 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, zerolog.ErrorLevel, conf.GetLogLevel())
 	require.True(t, conf.ConsoleLog)
 	require.Len(t, conf.AllowOrigins, 2)
+	require.Equal(t, testEnv["TENANT_AUTH_KEYS_URL"], conf.Auth.KeysURL)
+	require.Equal(t, testEnv["TENANT_AUTH_AUDIENCE"], conf.Auth.Audience)
+	require.Equal(t, testEnv["TENANT_AUTH_ISSUER"], conf.Auth.Issuer)
+	require.Equal(t, testEnv["TENANT_AUTH_COOKIE_DOMAIN"], conf.Auth.CookieDomain)
 	require.Equal(t, testEnv["TENANT_DATABASE_URL"], conf.Database.URL)
 	require.True(t, conf.Database.Insecure)
 	require.Equal(t, testEnv["TENANT_DATABASE_CERT_PATH"], conf.Database.CertPath)
@@ -146,6 +154,10 @@ func TestAllowAllOrigins(t *testing.T) {
 
 	conf.AllowOrigins = []string{"*"}
 	require.True(t, conf.AllowAllOrigins(), "expected allow all origins to be true when * is set")
+}
+
+func TestAuth(t *testing.T) {
+	// TODO: test AuthConfig validation
 }
 
 func TestDatabase(t *testing.T) {

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+	"github.com/rotationalio/ensign/pkg/tenant"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
@@ -16,7 +18,6 @@ func (suite *tenantTestSuite) TestTenantMemberCreate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	tenantID := ulid.Make().String()
-
 	defer cancel()
 
 	// Connect to a mock trtl database
@@ -28,8 +29,29 @@ func (suite *tenantTestSuite) TestTenantMemberCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err := suite.client.TenantMemberCreate(ctx, tenantID, &api.Member{})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TenantMemberCreate(ctx, tenantID, &api.Member{})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if tenant id is not a valid ULID.
-	_, err := suite.client.TenantMemberCreate(ctx, "tenantID", &api.Member{ID: "", Name: "member-example"})
+	_, err = suite.client.TenantMemberCreate(ctx, "tenantID", &api.Member{ID: "", Name: "member-example"})
 	suite.requireError(err, http.StatusBadRequest, "could not parse tenant id", "expected error when tenant id does not exist")
 
 	// Should return an error if the member id exists.
@@ -63,7 +85,6 @@ func (suite *tenantTestSuite) TestTenantMemberCreate() {
 func (suite *tenantTestSuite) TestMemberCreate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-
 	defer cancel()
 
 	// Connect to a mock trtl database
@@ -75,8 +96,29 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err := suite.client.MemberCreate(ctx, &api.Member{})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.MemberCreate(ctx, &api.Member{})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteMemberPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if member id exists.
-	_, err := suite.client.MemberCreate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member-example", Role: "Admin"})
+	_, err = suite.client.MemberCreate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member-example", Role: "Admin"})
 	suite.requireError(err, http.StatusBadRequest, "member id cannot be specified on create", "expected error when member id exists")
 
 	// Should return an error if the member name does not exist
@@ -102,16 +144,17 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 func (suite *tenantTestSuite) TestMemberDetail() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	member := &db.Member{
-		ID:   ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
-		Name: "member-example",
-		Role: "Admin",
-	}
 	defer cancel()
 
 	// Connect to mock trtl database
 	trtl := db.GetMock()
 	defer trtl.Reset()
+
+	member := &db.Member{
+		ID:   ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+		Name: "member-example",
+		Role: "Admin",
+	}
 
 	// Marshal the data with msgpack
 	data, err := member.MarshalValue()
@@ -122,12 +165,32 @@ func (suite *tenantTestSuite) TestMemberDetail() {
 	err = other.UnmarshalValue(data)
 	require.NoError(err, "could not unmarshal the member")
 
-	// Call the OnGet method and return test data.
+	// OnGet method should return test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return &pb.GetReply{
 			Value: data,
 		}, nil
 	}
+
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	_, err = suite.client.MemberDetail(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.MemberDetail(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.ReadMemberPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
 
 	// Should return an error if the member does not exist.
 	_, err = suite.client.MemberDetail(ctx, "invalid")
@@ -149,18 +212,18 @@ func (suite *tenantTestSuite) TestMemberDetail() {
 func (suite *tenantTestSuite) TestMemberUpdate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Connect to mock trtl database
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
 	member := &db.Member{
 		TenantID: ulid.MustParse("01GMTWFK4XZY597Y128KXQ4WHP"),
 		ID:       ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
 		Name:     "member001",
 		Role:     "Admin",
 	}
-
-	defer cancel()
-
-	// Connect to mock trtl database
-	trtl := db.GetMock()
-	defer trtl.Reset()
 
 	// Marshal the data with msgpack
 	data, err := member.MarshalValue()
@@ -171,27 +234,48 @@ func (suite *tenantTestSuite) TestMemberUpdate() {
 	err = other.UnmarshalValue(data)
 	require.NoError(err, "could not unmarshal the member")
 
-	// Call the OnGet method and return the test data.
+	// OnGet method should return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return &pb.GetReply{
 			Value: data,
 		}, nil
 	}
 
-	// Should return an error if the member does not exist
-	_, err = suite.client.MemberDetail(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse member id", "expected error when member does not exist")
-
-	// Call the OnPut method and return a PutReply.
+	// OnPut method should return a success response.
 	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
 		return &pb.PutReply{}, nil
 	}
 
-	// Should return an error if the member name does not exist.
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member001", Role: "Admin"})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member001", Role: "Admin"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteMemberPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if the member ID is not parseable.
+	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: "invalid", Name: "member001", Role: "Admin"})
+	suite.requireError(err, http.StatusBadRequest, "could not parse member id", "expected error when member does not exist")
+
+	// Should return an error if the member name is not provided.
 	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Role: "Admin"})
 	suite.requireError(err, http.StatusBadRequest, "member name is required", "expected error when member name does not exist")
 
-	// Should return an error if the member role does not exist.
+	// Should return an error if the member role is not provided.
 	_, err = suite.client.MemberUpdate(ctx, &api.Member{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "member001"})
 	suite.requireError(err, http.StatusBadRequest, "member role is required", "expected error when member role does not exist")
 
@@ -212,7 +296,6 @@ func (suite *tenantTestSuite) TestMemberDelete() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	memberID := "01ARZ3NDEKTSV4RRFFQ69G5FAV"
-
 	defer cancel()
 
 	// Connect to mock trtl database
@@ -224,8 +307,29 @@ func (suite *tenantTestSuite) TestMemberDelete() {
 		return &pb.DeleteReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"delete:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	err := suite.client.MemberDelete(ctx, memberID)
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	err = suite.client.MemberDelete(ctx, memberID)
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.DeleteMemberPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if the member does not exist.
-	err := suite.client.MemberDelete(ctx, "invalid")
+	err = suite.client.MemberDelete(ctx, "invalid")
 	suite.requireError(err, http.StatusBadRequest, "could not parse member id", "expected error when member does not exist")
 
 	err = suite.client.MemberDelete(ctx, memberID)

--- a/pkg/tenant/permissions.go
+++ b/pkg/tenant/permissions.go
@@ -1,0 +1,28 @@
+package tenant
+
+const (
+	// Tenant management
+	ReadTenantPermission   = "read:tenant"
+	WriteTenantPermission  = "write:tenant"
+	DeleteTenantPermission = "delete:tenant"
+
+	// Members management
+	ReadMemberPermission   = "read:member"
+	WriteMemberPermission  = "write:member"
+	DeleteMemberPermission = "delete:member"
+
+	// Projects management
+	ReadProjectPermission   = "read:project"
+	WriteProjectPermission  = "write:project"
+	DeleteProjectPermission = "delete:project"
+
+	// Topics management
+	ReadTopicPermission   = "read:topic"
+	WriteTopicPermission  = "write:topic"
+	DeleteTopicPermission = "delete:topic"
+
+	// API Keys management
+	ReadAPIKey   = "read:key"
+	WriteAPIKey  = "write:key"
+	DeleteAPIKey = "delete:key"
+)

--- a/pkg/tenant/projects_test.go
+++ b/pkg/tenant/projects_test.go
@@ -255,6 +255,7 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 	// User must have the correct permissions
 	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
 	_, err = suite.client.TenantProjectCreate(ctx, "tenantID", &api.Project{ID: "", Name: "project001"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
 
 	// Set valid permissions for the rest of the tests
 	claims.Permissions = []string{tenant.WriteTenantPermission}

--- a/pkg/tenant/projects_test.go
+++ b/pkg/tenant/projects_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+	"github.com/rotationalio/ensign/pkg/tenant"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
@@ -15,17 +17,17 @@ import (
 func (suite *tenantTestSuite) TestProjectDetail() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	project := &db.Project{
-		TenantID: ulid.MustParse("01GMTWFK4XZY597Y128KXQ4WHP"),
-		ID:       ulid.MustParse("01GKKYAWC4PA72YC53RVXAEC67"),
-		Name:     "project001",
-	}
-
 	defer cancel()
 
 	// Connect to mock trtl database.
 	trtl := db.GetMock()
 	defer trtl.Reset()
+
+	project := &db.Project{
+		TenantID: ulid.MustParse("01GMTWFK4XZY597Y128KXQ4WHP"),
+		ID:       ulid.MustParse("01GKKYAWC4PA72YC53RVXAEC67"),
+		Name:     "project001",
+	}
 
 	// Marshal the project data with msgpack.
 	data, err := project.MarshalValue()
@@ -42,6 +44,26 @@ func (suite *tenantTestSuite) TestProjectDetail() {
 			Value: data,
 		}, nil
 	}
+
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	_, err = suite.client.ProjectDetail(ctx, "invalid")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
+	_, err = suite.client.ProjectDetail(ctx, "invalid")
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.ReadProjectPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
 
 	// Should return an error if the project does not exist.
 	_, err = suite.client.ProjectDetail(ctx, "invalid")
@@ -70,17 +92,17 @@ func (suite *tenantTestSuite) TestProjectDetail() {
 func (suite *tenantTestSuite) TestProjectUpdate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	project := &db.Project{
-		TenantID: ulid.MustParse("01GMTWFK4XZY597Y128KXQ4WHP"),
-		ID:       ulid.MustParse("01GKKYAWC4PA72YC53RVXAEC67"),
-		Name:     "project001",
-	}
-
 	defer cancel()
 
 	// Connect to mock trtl database.
 	trtl := db.GetMock()
 	defer trtl.Reset()
+
+	project := &db.Project{
+		TenantID: ulid.MustParse("01GMTWFK4XZY597Y128KXQ4WHP"),
+		ID:       ulid.MustParse("01GKKYAWC4PA72YC53RVXAEC67"),
+		Name:     "project001",
+	}
 
 	// Marshal the project data with msgpack.
 	data, err := project.MarshalValue()
@@ -91,23 +113,44 @@ func (suite *tenantTestSuite) TestProjectUpdate() {
 	err = other.UnmarshalValue(data)
 	require.NoError(err, "could not unmarshal the project")
 
-	// Call the OnGet method and return the test data.
+	// OnGet method should return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return &pb.GetReply{
 			Value: data,
 		}, nil
 	}
 
-	// Should return an error if the project does not exist.
-	_, err = suite.client.ProjectDetail(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse project ulid", "expected error when project does not exist")
-
-	// Call the OnPut method and return a PutReply.
+	// OnPut method should return a success response.
 	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
 		return &pb.PutReply{}, nil
 	}
 
-	// Should return an error if the project name does not exist.
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err = suite.client.ProjectUpdate(ctx, &api.Project{ID: "invalid"})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
+	_, err = suite.client.ProjectUpdate(ctx, &api.Project{ID: "invalid"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteProjectPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if the project ID is not parseable.
+	_, err = suite.client.ProjectUpdate(ctx, &api.Project{ID: "invalid"})
+	suite.requireError(err, http.StatusBadRequest, "could not parse project ulid", "expected error when project does not exist")
+
+	// Should return an error if the project name is missing.
 	_, err = suite.client.ProjectUpdate(ctx, &api.Project{ID: "01GKKYAWC4PA72YC53RVXAEC67"})
 	suite.requireError(err, http.StatusBadRequest, "project name is required", "expected error when project name does not exist")
 
@@ -126,15 +169,14 @@ func (suite *tenantTestSuite) TestProjectUpdate() {
 		return nil, errors.New("key not found")
 	}
 
-	_, err = suite.client.ProjectDetail(ctx, "01GKKYAWC4PA72YC53RVXAEC67")
-	suite.requireError(err, http.StatusNotFound, "could not retrieve project", "expected error when project ID is not found")
+	_, err = suite.client.ProjectUpdate(ctx, &api.Project{ID: "01GKKYAWC4PA72YC53RVXAEC67", Name: "project001"})
+	suite.requireError(err, http.StatusNotFound, "project not found", "expected error when project ID is not found")
 }
 
 func (suite *tenantTestSuite) TestProjectDelete() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	projectID := "01GKKYAWC4PA72YC53RVXAEC67"
-
 	defer cancel()
 
 	// Connect to mock trtl database.
@@ -146,8 +188,29 @@ func (suite *tenantTestSuite) TestProjectDelete() {
 		return &pb.DeleteReply{}, nil
 	}
 
-	// Should return an error if the project does not exist.
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"delete:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
 	err := suite.client.ProjectDelete(ctx, "invalid")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
+	err = suite.client.ProjectDelete(ctx, "invalid")
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.DeleteProjectPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if the project does not exist.
+	err = suite.client.ProjectDelete(ctx, "invalid")
 	suite.requireError(err, http.StatusBadRequest, "could not parse project ulid", "expected error when project does not exist")
 
 	err = suite.client.ProjectDelete(ctx, projectID)
@@ -166,7 +229,6 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	tenantID := ulid.Make().String()
-
 	defer cancel()
 
 	// Connect to mock trtl database.
@@ -178,8 +240,28 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 		return &pb.PutReply{}, nil
 	}
 
-	// Should return an error if tenant id is not a valid ULID.
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
 	_, err := suite.client.TenantProjectCreate(ctx, "tenantID", &api.Project{ID: "", Name: "project001"})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
+	_, err = suite.client.TenantProjectCreate(ctx, "tenantID", &api.Project{ID: "", Name: "project001"})
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if tenant id is not a valid ULID.
+	_, err = suite.client.TenantProjectCreate(ctx, "tenantID", &api.Project{ID: "", Name: "project001"})
 	suite.requireError(err, http.StatusBadRequest, "could not parse tenant id", "expected error when tenant id does not exist")
 
 	// Should return an error if the project ID exists.
@@ -203,7 +285,6 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 func (suite *tenantTestSuite) TestProjectCreate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-
 	defer cancel()
 
 	// Connect to mock trtl database.
@@ -215,8 +296,29 @@ func (suite *tenantTestSuite) TestProjectCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Set the initial claims fixture.
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err := suite.client.ProjectCreate(ctx, &api.Project{ID: "", Name: "project001"})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
+	_, err = suite.client.ProjectCreate(ctx, &api.Project{ID: "", Name: "project001"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have correct permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteProjectPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if a project ID exists.
-	_, err := suite.client.ProjectCreate(ctx, &api.Project{ID: "01GKKYAWC4PA72YC53RVXAEC67", Name: "project001"})
+	_, err = suite.client.ProjectCreate(ctx, &api.Project{ID: "01GKKYAWC4PA72YC53RVXAEC67", Name: "project001"})
 	suite.requireError(err, http.StatusBadRequest, "project id cannot be specified on create", "expected error when project id exists")
 
 	// Should return an error if a project name does not exist.

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/rotationalio/ensign/pkg"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
+	mw "github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/config"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
@@ -177,7 +179,22 @@ func (s *Server) Shutdown() (err error) {
 }
 
 // Sets up the server's middleware and routes
-func (s *Server) setupRoutes() error {
+func (s *Server) setupRoutes() (err error) {
+	// Set the authentication overrides from the configuration
+	opts := middleware.AuthOptions{
+		Audience: s.conf.Auth.Audience,
+		Issuer:   s.conf.Auth.Issuer,
+		KeysURL:  s.conf.Auth.KeysURL,
+	}
+
+	// In maintenance mode authentication is disabled
+	var authenticator gin.HandlerFunc
+	if !s.conf.Maintenance {
+		if authenticator, err = mw.Authenticate(middleware.WithAuthOptions(opts)); err != nil {
+			return err
+		}
+	}
+
 	// Instantiate Sentry Handlers
 	var tags gin.HandlerFunc
 	if s.conf.Sentry.UseSentry() {
@@ -235,68 +252,103 @@ func (s *Server) setupRoutes() error {
 		}
 	}
 
+	// CSRF protection is individually configured for POST, PUT, PATCH, and DELETE routes
+	csrf := mw.DoubleCookie()
+
 	// Adds the v1 API routes
 	v1 := s.router.Group("v1")
 	{
 		// Heartbeat route (authentication not required)
 		v1.GET("/status", s.Status)
 
+		// Set cookies for CSRF protection (authentication not required)
+		v1.GET("/login", s.ProtectLogin)
+
 		// Notification signups (authentication not required)
 		v1.POST("/notifications/signup", s.SignUp)
 
-		// Adds tenant to the API routes
-		// Routes to tenants
-		v1.GET("/tenant", s.TenantList)
-		v1.GET("/tenant/:tenantID", s.TenantDetail)
-		v1.POST("/tenant", s.TenantCreate)
-		v1.PUT("/tenant/:tenantID", s.TenantUpdate)
-		v1.DELETE("/tenant/:tenantID", s.TenantDelete)
+		// Tenant API routes must be authenticated
+		tenant := v1.Group("/tenant", authenticator)
+		{
+			tenant.GET("", mw.Authorize(ReadTenantPermission), s.TenantList)
+			tenant.POST("", csrf, mw.Authorize(WriteTenantPermission), s.TenantCreate)
+			tenant.GET("/:tenantID", mw.Authorize(ReadTenantPermission), s.TenantDetail)
+			tenant.PUT("/:tenantID", csrf, mw.Authorize(WriteTenantPermission), s.TenantUpdate)
+			tenant.DELETE("/:tenantID", csrf, mw.Authorize(DeleteTenantPermission), s.TenantDelete)
 
-		// Routes to members
-		v1.GET("/tenant/:tenantID/members", s.TenantMemberList)
-		v1.POST("/tenant/:tenantID/members", s.TenantMemberCreate)
+			tenant.GET("/:tenantID/members", mw.Authorize(ReadTenantPermission), s.TenantMemberList)
+			tenant.POST("/:tenantID/members", csrf, mw.Authorize(WriteTenantPermission), s.TenantMemberCreate)
 
-		v1.GET("/members", s.MemberList)
-		v1.GET("/members/:memberID", s.MemberDetail)
-		v1.POST("/members", s.MemberCreate)
-		v1.PUT("/members/:memberID", s.MemberUpdate)
-		v1.DELETE("/members/:memberID", s.MemberDelete)
+			tenant.GET("/:tenantID/projects", mw.Authorize(ReadTenantPermission), s.TenantProjectList)
+			tenant.POST("/:tenantID/projects", csrf, mw.Authorize(WriteTenantPermission), s.TenantProjectCreate)
+		}
 
-		// Routes to projects
-		v1.GET("/tenant/:tenantID/projects", s.TenantProjectList)
-		v1.POST("/tenant/:tenantID/projects", s.TenantProjectCreate)
+		// Members API routes must be authenticated
+		members := v1.Group("/members", authenticator)
+		{
+			members.GET("", mw.Authorize(ReadMemberPermission), s.MemberList)
+			members.POST("", csrf, mw.Authorize(WriteMemberPermission), s.MemberCreate)
+			members.GET("/:memberID", mw.Authorize(ReadMemberPermission), s.MemberDetail)
+			members.PUT("/:memberID", csrf, mw.Authorize(WriteMemberPermission), s.MemberUpdate)
+			members.DELETE("/:memberID", csrf, mw.Authorize(DeleteMemberPermission), s.MemberDelete)
+		}
 
-		v1.GET("/projects", s.ProjectList)
-		v1.GET("/projects/:projectID", s.ProjectDetail)
-		v1.POST("/projects", s.ProjectCreate)
-		v1.PUT("/projects/:projectID", s.ProjectUpdate)
-		v1.DELETE("/projects/:projectID", s.ProjectDelete)
+		// Projects API routes must be authenticated
+		projects := v1.Group("/projects", authenticator)
+		{
+			projects.GET("", mw.Authorize(ReadProjectPermission), s.ProjectList)
+			projects.POST("", csrf, mw.Authorize(WriteProjectPermission), s.ProjectCreate)
+			projects.GET("/:projectID", mw.Authorize(ReadProjectPermission), s.ProjectDetail)
+			projects.PUT("/:projectID", csrf, mw.Authorize(WriteProjectPermission), s.ProjectUpdate)
+			projects.DELETE("/:projectID", csrf, mw.Authorize(DeleteProjectPermission), s.ProjectDelete)
 
-		// Routes to topics
-		v1.GET("/projects/:projectID/topics", s.ProjectTopicList)
-		v1.POST("/projects/:projectID/topics", s.ProjectTopicCreate)
+			projects.GET("/:projectID/topics", mw.Authorize(ReadProjectPermission), s.ProjectTopicList)
+			projects.POST("/:projectID/topics", csrf, mw.Authorize(WriteProjectPermission), s.ProjectTopicCreate)
 
-		v1.GET("/topics", s.TopicList)
-		v1.POST("/topics", s.TopicCreate)
-		v1.GET("/topics/:topicID", s.TopicDetail)
-		v1.PUT("/topics/:topicID", s.TopicUpdate)
-		v1.DELETE("/topics/:topicID", s.TopicDelete)
+			projects.GET("/:projectID/apikeys", mw.Authorize(ReadProjectPermission), s.ProjectAPIKeyList)
+			projects.POST("/:projectID/apikeys", csrf, mw.Authorize(WriteProjectPermission), s.ProjectAPIKeyCreate)
+		}
 
-		// Routes to APIKeys
-		v1.GET("/projects/:projectID/aoikeys", s.ProjectAPIKeyList)
-		v1.POST("/projects/:projectID/apikeys", s.ProjectAPIKeyCreate)
+		// Topics API routes must be authenticated
+		topics := v1.Group("/topics", authenticator)
+		{
+			topics.GET("", mw.Authorize(ReadTopicPermission), s.TopicList)
+			topics.POST("", csrf, mw.Authorize(WriteTopicPermission), s.TopicCreate)
+			topics.GET("/:topicID", mw.Authorize(ReadTopicPermission), s.TopicDetail)
+			topics.PUT("/:topicID", csrf, mw.Authorize(WriteTopicPermission), s.TopicUpdate)
+			topics.DELETE("/:topicID", csrf, mw.Authorize(DeleteTopicPermission), s.TopicDelete)
+		}
 
-		v1.GET("/apikeys", s.APIKeyList)
-		v1.GET("/apikeys/:apiKeyID", s.APIKeyDetail)
-		v1.POST("/apikeys", s.APIKeyCreate)
-		v1.PUT("/apikeys/:apiKeyID", s.APIKeyUpdate)
-		v1.DELETE("/apikeys/:apiKeyID", s.APIKeyDelete)
+		// API key routes must be authenticated
+		apikeys := v1.Group("/apikeys", authenticator)
+		{
+			apikeys.GET("", mw.Authorize(ReadAPIKey), s.APIKeyList)
+			apikeys.POST("", csrf, mw.Authorize(WriteAPIKey), s.APIKeyCreate)
+			apikeys.GET("/:apiKeyID", mw.Authorize(ReadAPIKey), s.APIKeyDetail)
+			apikeys.PUT("/:apiKeyID", csrf, mw.Authorize(WriteAPIKey), s.APIKeyUpdate)
+			apikeys.DELETE("/:apiKeyID", csrf, mw.Authorize(DeleteAPIKey), s.APIKeyDelete)
+		}
 	}
 
 	// NotFound and NotAllowed routes
 	s.router.NoRoute(api.NotFound)
 	s.router.NoMethod(api.NotAllowed)
 	return nil
+}
+
+// Set the maximum age of login protection cookies.
+const doubleCookiesMaxAge = time.Minute * 10
+
+// ProtectLogin prepares the front-end for login by setting the double cookie
+// tokens for CSRF protection.
+func (s *Server) ProtectLogin(c *gin.Context) {
+	expiresAt := time.Now().Add(doubleCookiesMaxAge)
+	if err := mw.SetDoubleCookieToken(c, s.conf.Auth.CookieDomain, expiresAt); err != nil {
+		log.Error().Err(err).Msg("could not set cookies")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not set cookies"))
+		return
+	}
+	c.JSON(http.StatusOK, &api.Reply{Success: true})
 }
 
 func (s *Server) SetHealth(health bool) {

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/rotationalio/ensign/pkg"
-	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	mw "github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/config"
@@ -181,7 +180,7 @@ func (s *Server) Shutdown() (err error) {
 // Sets up the server's middleware and routes
 func (s *Server) setupRoutes() (err error) {
 	// Set the authentication overrides from the configuration
-	opts := middleware.AuthOptions{
+	opts := mw.AuthOptions{
 		Audience: s.conf.Auth.Audience,
 		Issuer:   s.conf.Auth.Issuer,
 		KeysURL:  s.conf.Auth.KeysURL,
@@ -190,7 +189,7 @@ func (s *Server) setupRoutes() (err error) {
 	// In maintenance mode authentication is disabled
 	var authenticator gin.HandlerFunc
 	if !s.conf.Maintenance {
-		if authenticator, err = mw.Authenticate(middleware.WithAuthOptions(opts)); err != nil {
+		if authenticator, err = mw.Authenticate(mw.WithAuthOptions(opts)); err != nil {
 			return err
 		}
 	}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -188,10 +188,8 @@ func (s *Server) setupRoutes() (err error) {
 
 	// In maintenance mode authentication is disabled
 	var authenticator gin.HandlerFunc
-	if !s.conf.Maintenance {
-		if authenticator, err = mw.Authenticate(mw.WithAuthOptions(opts)); err != nil {
-			return err
-		}
+	if authenticator, err = mw.Authenticate(mw.WithAuthOptions(opts)); err != nil {
+		return err
 	}
 
 	// Instantiate Sentry Handlers
@@ -333,21 +331,6 @@ func (s *Server) setupRoutes() (err error) {
 	s.router.NoRoute(api.NotFound)
 	s.router.NoMethod(api.NotAllowed)
 	return nil
-}
-
-// Set the maximum age of login protection cookies.
-const doubleCookiesMaxAge = time.Minute * 10
-
-// ProtectLogin prepares the front-end for login by setting the double cookie
-// tokens for CSRF protection.
-func (s *Server) ProtectLogin(c *gin.Context) {
-	expiresAt := time.Now().Add(doubleCookiesMaxAge)
-	if err := mw.SetDoubleCookieToken(c, s.conf.Auth.CookieDomain, expiresAt); err != nil {
-		log.Error().Err(err).Msg("could not set cookies")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not set cookies"))
-		return
-	}
-	c.JSON(http.StatusOK, &api.Reply{Success: true})
 }
 
 func (s *Server) SetHealth(health bool) {

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+	"github.com/rotationalio/ensign/pkg/tenant"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
@@ -14,7 +16,6 @@ import (
 func (suite *tenantTestSuite) TestTenantList() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-
 	defer cancel()
 
 	// Connect to a mock trtl database
@@ -26,13 +27,32 @@ func (suite *tenantTestSuite) TestTenantList() {
 		return nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	_, err := suite.client.TenantList(ctx, &api.PageQuery{})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TenantList(ctx, &api.PageQuery{})
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.ReadTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	req := &api.PageQuery{
 		PageSize:      2,
 		NextPageToken: "12",
 	}
 
 	// TODO: Test length of values assigned to *api.TenantPage
-	_, err := suite.client.TenantList(ctx, req)
+	_, err = suite.client.TenantList(ctx, req)
 	require.NoError(err, "could not list tenants")
 }
 
@@ -50,8 +70,29 @@ func (suite *tenantTestSuite) TestTenantCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"create:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set client csrf protection")
+	_, err := suite.client.TenantCreate(ctx, &api.Tenant{})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TenantCreate(ctx, &api.Tenant{})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if tenant id exists.
-	_, err := suite.client.TenantCreate(ctx, &api.Tenant{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "tenant01", EnvironmentType: "prod"})
+	_, err = suite.client.TenantCreate(ctx, &api.Tenant{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "tenant01", EnvironmentType: "prod"})
 	suite.requireError(err, http.StatusBadRequest, "tenant id cannot be specified on create", "expected error when tenant id exists")
 
 	// Should return an error if tenant name does not exist.
@@ -77,19 +118,20 @@ func (suite *tenantTestSuite) TestTenantCreate() {
 func (suite *tenantTestSuite) TestTenantDetail() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	tenant := &db.Tenant{
-		ID:              ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
-		Name:            "example-staging",
-		EnvironmentType: "prod",
-	}
 	defer cancel()
 
 	// Connect to a mock trtl database
 	trtl := db.GetMock()
 	defer trtl.Reset()
 
+	fixture := &db.Tenant{
+		ID:              ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+		Name:            "example-staging",
+		EnvironmentType: "prod",
+	}
+
 	// Marshal the data with msgpack
-	data, err := tenant.MarshalValue()
+	data, err := fixture.MarshalValue()
 	require.NoError(err, "could not marshal the tenant")
 
 	// Unmarshal the data with msgpack
@@ -103,6 +145,26 @@ func (suite *tenantTestSuite) TestTenantDetail() {
 			Value: data,
 		}, nil
 	}
+
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	_, err = suite.client.TenantDetail(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TenantDetail(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV")
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.ReadTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
 
 	// Should return an error if the tenant does not exist
 	_, err = suite.client.TenantDetail(ctx, "invalid")
@@ -125,20 +187,20 @@ func (suite *tenantTestSuite) TestTenantDetail() {
 func (suite *tenantTestSuite) TestTenantUpdate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	tenant := &db.Tenant{
-		ID:              ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
-		Name:            "example-staging",
-		EnvironmentType: "prod",
-	}
-
 	defer cancel()
 
 	// Connect to mock trtl database
 	trtl := db.GetMock()
 	defer trtl.Reset()
 
+	fixture := &db.Tenant{
+		ID:              ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+		Name:            "example-staging",
+		EnvironmentType: "prod",
+	}
+
 	// Marshal the data with msgpack
-	data, err := tenant.MarshalValue()
+	data, err := fixture.MarshalValue()
 	require.NoError(err, "could not marshal the tenant")
 
 	// Unmarshal the data with msgpack
@@ -146,21 +208,42 @@ func (suite *tenantTestSuite) TestTenantUpdate() {
 	err = other.UnmarshalValue(data)
 	require.NoError(err, "could not unmarshal the tenant")
 
-	// Call the OnGet method and return the test data.
+	// OnGet should return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return &pb.GetReply{
 			Value: data,
 		}, nil
 	}
 
-	// Should return an error if the tenant does not exist
-	_, err = suite.client.TenantDetail(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse tenant id", "expected error when tenant does not exist")
-
-	// Call the OnPut method and return a PutReply.
+	// OnPut should return a success reply.
 	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
 		return &pb.PutReply{}, nil
 	}
+
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"create:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err = suite.client.TenantUpdate(ctx, &api.Tenant{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "example-staging", EnvironmentType: "prod"})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TenantUpdate(ctx, &api.Tenant{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", Name: "example-staging", EnvironmentType: "prod"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if the tenant does not exist
+	_, err = suite.client.TenantUpdate(ctx, &api.Tenant{ID: "invalid", Name: "example-staging", EnvironmentType: "prod"})
+	suite.requireError(err, http.StatusBadRequest, "could not parse tenant id", "expected error when tenant does not exist")
 
 	// Should return an error if the tenant name does not exist
 	_, err = suite.client.TenantUpdate(ctx, &api.Tenant{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV", EnvironmentType: "prod"})
@@ -187,7 +270,6 @@ func (suite *tenantTestSuite) TestTenantDelete() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	tenantID := "01ARZ3NDEKTSV4RRFFQ69G5FAV"
-
 	defer cancel()
 
 	// Connect to a mock trtl database.
@@ -199,8 +281,29 @@ func (suite *tenantTestSuite) TestTenantDelete() {
 		return &pb.DeleteReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"delete:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	err := suite.client.TenantDelete(ctx, tenantID)
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	err = suite.client.TenantDelete(ctx, tenantID)
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permission")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.DeleteTenantPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if the tenant does not exist
-	err := suite.client.TenantDelete(ctx, "invalid")
+	err = suite.client.TenantDelete(ctx, "invalid")
 	suite.requireError(err, http.StatusBadRequest, "could not parse tenant id", "expected error when tenant does not exist")
 
 	err = suite.client.TenantDelete(ctx, tenantID)

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -41,6 +41,7 @@ func (suite *tenantTestSuite) TestTenantList() {
 	// User must have the correct permissions
 	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
 	_, err = suite.client.TenantList(ctx, &api.PageQuery{})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have the correct permissions")
 
 	// Set valid permissions for the rest of the tests
 	claims.Permissions = []string{tenant.ReadTenantPermission}

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -117,6 +117,11 @@ func (s *Server) ProjectTopicCreate(c *gin.Context) {
 	c.JSON(http.StatusCreated, out)
 }
 
+// Route: /topics
+func (s *Server) TopicCreate(c *gin.Context) {
+	c.JSON(http.StatusNotImplemented, "not implemented yet")
+}
+
 // TopicList retrieves all topics assigned to an organization
 // and returns a 200 OK response.
 //

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+	"github.com/rotationalio/ensign/pkg/tenant"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
@@ -15,17 +17,17 @@ import (
 func (suite *tenantTestSuite) TestTopicDetail() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	topic := &db.Topic{
-		ProjectID: ulid.MustParse("01GNA91N6WMCWNG9MVSK47ZS88"),
-		ID:        ulid.MustParse("01GNA926JCTKDH3VZBTJM8MAF6"),
-		Name:      "topic001",
-	}
-
 	defer cancel()
 
 	// Connect to mock trtl database
 	trtl := db.GetMock()
 	defer trtl.Reset()
+
+	topic := &db.Topic{
+		ProjectID: ulid.MustParse("01GNA91N6WMCWNG9MVSK47ZS88"),
+		ID:        ulid.MustParse("01GNA926JCTKDH3VZBTJM8MAF6"),
+		Name:      "topic001",
+	}
 
 	// Marshal the topic data with msgpack.
 	data, err := topic.MarshalValue()
@@ -42,6 +44,26 @@ func (suite *tenantTestSuite) TestTopicDetail() {
 			Value: data,
 		}, nil
 	}
+
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	_, err = suite.client.TopicDetail(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TopicDetail(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permission")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.ReadTopicPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
 
 	// Should return an error if the topic does not exist.
 	_, err = suite.client.TopicDetail(ctx, "invalid")
@@ -70,17 +92,17 @@ func (suite *tenantTestSuite) TestTopicDetail() {
 func (suite *tenantTestSuite) TestTopicUpdate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	topic := &db.Topic{
-		ProjectID: ulid.MustParse("01GNA91N6WMCWNG9MVSK47ZS88"),
-		ID:        ulid.MustParse("01GNA926JCTKDH3VZBTJM8MAF6"),
-		Name:      "topic001",
-	}
-
 	defer cancel()
 
 	// Connect to mock trtl database.
 	trtl := db.GetMock()
 	defer trtl.Reset()
+
+	topic := &db.Topic{
+		ProjectID: ulid.MustParse("01GNA91N6WMCWNG9MVSK47ZS88"),
+		ID:        ulid.MustParse("01GNA926JCTKDH3VZBTJM8MAF6"),
+		Name:      "topic001",
+	}
 
 	// Marshal the topic data with msgpack.
 	data, err := topic.MarshalValue()
@@ -91,25 +113,46 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 	err = other.UnmarshalValue(data)
 	require.NoError(err, "could not unmarshal the topic data")
 
-	// Call the OnGet method and return the test data.
+	// OnGet method should return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return &pb.GetReply{
 			Value: data,
 		}, nil
 	}
 
-	// Should return an error if the topic does not exist.
-	_, err = suite.client.TopicDetail(ctx, "invalid")
-	suite.requireError(err, http.StatusBadRequest, "could not parse topic ulid", "expected error when topic does not exist")
-
-	// Call the OnPut method and return a PutReply.
+	// OnPut method should return a success response.
 	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
 		return &pb.PutReply{}, nil
 	}
 
-	// Should return an error if the topic name does not exist.
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set client csrf protection")
 	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6"})
-	suite.requireError(err, http.StatusBadRequest, "topic name is required", "expected error when topic name does not exist")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permission")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteTopicPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if the topic is not parseable.
+	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "invalid"})
+	suite.requireError(err, http.StatusBadRequest, "could not parse topic ulid", "expected error when topic is not parseable")
+
+	// Should return an error if the topic name is missing.
+	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6"})
+	suite.requireError(err, http.StatusBadRequest, "topic name is required", "expected error when topic name is missing")
 
 	// Create a topic test fixture.
 	req := &api.Topic{
@@ -127,15 +170,14 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 		return nil, errors.New("key not found")
 	}
 
-	_, err = suite.client.TopicDetail(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
-	suite.requireError(err, http.StatusNotFound, "could not retrieve topic", "expected error when topic ID is not found")
+	_, err = suite.client.TopicUpdate(ctx, &api.Topic{ID: "01GNA926JCTKDH3VZBTJM8MAF6", Name: "topic001"})
+	suite.requireError(err, http.StatusNotFound, "topic not found", "expected error when topic ID is not found")
 }
 
 func (suite *tenantTestSuite) TestTopicDelete() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	topicID := "01GNA926JCTKDH3VZBTJM8MAF6"
-
 	defer cancel()
 
 	// Connect to mock trtl database.
@@ -147,8 +189,29 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 		return &pb.DeleteReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"delete:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set client csrf protection")
+	err := suite.client.TopicDelete(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	err = suite.client.TopicDelete(ctx, "01GNA926JCTKDH3VZBTJM8MAF6")
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permission")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.DeleteTopicPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if the topic does not exist.
-	err := suite.client.TopicDelete(ctx, "invalid")
+	err = suite.client.TopicDelete(ctx, "invalid")
 	suite.requireError(err, http.StatusBadRequest, "could not parse topic ulid", "expected error when topic does not exist")
 
 	err = suite.client.TopicDelete(ctx, topicID)
@@ -167,7 +230,6 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 	require := suite.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	projectID := ulid.Make().String()
-
 	defer cancel()
 
 	// Connect to mock trtl database.
@@ -179,8 +241,29 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 		return &pb.PutReply{}, nil
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"create:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	require.NoError(suite.SetClientCSRFProtection(), "could not set client csrf protection")
+	_, err := suite.client.ProjectTopicCreate(ctx, projectID, &api.Topic{ID: "", Name: "topic-example"})
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.ProjectTopicCreate(ctx, projectID, &api.Topic{ID: "", Name: "topic-example"})
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permission")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{tenant.WriteProjectPermission}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
 	// Should return an error if project id is not a valid ULID.
-	_, err := suite.client.ProjectTopicCreate(ctx, "projectID", &api.Topic{ID: "", Name: "topic-example"})
+	_, err = suite.client.ProjectTopicCreate(ctx, "projectID", &api.Topic{ID: "", Name: "topic-example"})
 	suite.requireError(err, http.StatusBadRequest, "could not parse project id", "expected error when project id does not exist")
 
 	// Should return an error if topic id exists.


### PR DESCRIPTION
### Scope of changes

This integrates the quarterdeck authentication and authorization middlewares implemented in a previous PR into the tenant server.

There is a fair bit of related changes made, mostly to get the tests to a working state again after the integration.

Fixes SC-10289

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Tests should still run with the configured middleware and I believe the docker compose should at least start all the services.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Permissions - do we need to open an additional story to clean those up / figure out which ones we need?
- [ ] Middleware is added as described in SC-10289