### PR TITLE
Integrate AuthN and AuthZ into Quarterdeck

### DIFF
--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -50,6 +50,7 @@ func New(endpoint string, opts ...ClientOption) (_ QuarterdeckClient, err error)
 type APIv1 struct {
 	endpoint *url.URL     // the base url for all requests
 	client   *http.Client // used to make http requests to the server
+	creds    Credentials  // default credentials used to authorize requests
 }
 
 // Ensure the APIv1 implements the QuarterdeckClient interface
@@ -265,7 +266,14 @@ func (s *APIv1) NewRequest(ctx context.Context, method, path string, data interf
 	req.Header.Add("Accept-Encoding", acceptEncode)
 	req.Header.Add("Content-Type", contentType)
 
-	// TODO: add authentication if its available (add Authorization header)
+	// add authentication if its available (add Authorization header)
+	if s.creds != nil {
+		var token string
+		if token, err = s.creds.AccessToken(); err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	// Add CSRF protection if its available
 	if s.client.Jar != nil {

--- a/pkg/quarterdeck/api/v1/creds.go
+++ b/pkg/quarterdeck/api/v1/creds.go
@@ -1,0 +1,20 @@
+package api
+
+// Credentials provides a basic interface for loading an access token from Quarterdeck
+// into the Quarterdeck API client. Credentials can be loaded from disk, generated, or
+// feched from a passthrough request.
+type Credentials interface {
+	AccessToken() (string, error)
+}
+
+// A Token is just the JWT base64 encoded token string that is obtained from
+// Quarterdeck either using the authtest server or from a login with the client.
+type Token string
+
+// Token implements the credentials interface and performs limited validation.
+func (t Token) AccessToken() (string, error) {
+	if string(t) == "" {
+		return "", ErrInvalidCredentials
+	}
+	return string(t), nil
+}

--- a/pkg/quarterdeck/api/v1/errors.go
+++ b/pkg/quarterdeck/api/v1/errors.go
@@ -19,6 +19,8 @@ var (
 	ErrMissingRegisterField = errors.New("name and email address are required")
 	ErrPasswordMismatch     = errors.New("passwords do not match")
 	ErrPasswordTooWeak      = errors.New("password is too weak: use a combination of upper and lower case letters, numbers, and special characters")
+	ErrInvalidCredentials   = errors.New("quarterdeck credentials are missing or invalid")
+	ErrExpiredCredentials   = errors.New("quarterdeck credentials have expired")
 )
 
 // Construct a new response for an error or simply return unsuccessful.

--- a/pkg/quarterdeck/api/v1/options.go
+++ b/pkg/quarterdeck/api/v1/options.go
@@ -13,3 +13,27 @@ func WithClient(client *http.Client) ClientOption {
 		return nil
 	}
 }
+
+func WithCredentials(creds Credentials) ClientOption {
+	return func(c *APIv1) error {
+		c.creds = creds
+		return nil
+	}
+}
+
+// RequestOption allows us to configure individual APIv1 client requests
+// TODO: this is just a hack that modifies the request to get us started, but we will
+// likely want to consider what design pattern we want to use in SC-12797.
+type RequestOption func(req *http.Request) error
+
+// WithRPCCredentials overwrites any existing Authorize header with the specified creds.
+func WithRPCCredentials(creds Credentials) RequestOption {
+	return func(req *http.Request) (err error) {
+		var token string
+		if token, err = creds.AccessToken(); err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
+}

--- a/pkg/quarterdeck/apikeys_test.go
+++ b/pkg/quarterdeck/apikeys_test.go
@@ -14,10 +14,12 @@ func (suite *quarterdeckTestSuite) TestAPIKeyList() {
 
 	// TODO: implement actual tests
 	req := &api.PageQuery{}
-	rep, err := suite.client.APIKeyList(ctx, req)
-	require.NoError(err, "should return an empty list")
-	require.Empty(rep.APIKeys)
-	require.Empty(rep.NextPageToken)
+	_, err := suite.client.APIKeyList(ctx, req)
+	require.Error(err, "unauthorized requests should not return a response")
+
+	// require.NoError(err, "should return an empty list")
+	// require.Empty(rep.APIKeys)
+	// require.Empty(rep.NextPageToken)
 }
 
 func (suite *quarterdeckTestSuite) TestAPIKeyCreate() {


### PR DESCRIPTION
### Scope of changes

Implements the `Authenticate` and `Authorize` endpoints into Quarterdeck and creates some client stubs for authentication to setup testing.

Fixes SC-12739

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR influences SC-12797 because it starts towards a solution. 

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.