### PR TITLE
Quarterdeck passthrough credentials

### DIFF
--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-const ContextCreds = "creds"
+type ContextCredsKey struct{}
 
 // New creates a new API v1 client that implements the Quarterdeck Client interface.
 func New(endpoint string, opts ...ClientOption) (_ QuarterdeckClient, err error) {
@@ -331,7 +331,7 @@ func (s *APIv1) Do(req *http.Request, data interface{}, checkStatus bool) (rep *
 // ContextWithToken returns a new context from the provided context with the specified
 // token added to it.
 func ContextWithToken(ctx context.Context, token string) context.Context {
-	return context.WithValue(ctx, ContextCreds, Token(token))
+	return context.WithValue(ctx, ContextCredsKey{}, Token(token))
 }
 
 // CredsFromContext returns the Credentials from the provided context or nil if not
@@ -340,7 +340,7 @@ func CredsFromContext(ctx context.Context) Credentials {
 	if ctx == nil {
 		return nil
 	}
-	if creds, ok := ctx.Value(ContextCreds).(Credentials); ok {
+	if creds, ok := ctx.Value(ContextCredsKey{}).(Credentials); ok {
 		return creds
 	}
 	return nil

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -86,7 +86,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, "Bearer newtoken", req.Header.Get("Authorization"), "expected the authorization header to be set")
 
 	// Test that malformed credentials in the request context are ignored
-	ctx = context.WithValue(context.Background(), api.ContextCreds, "badtoken")
+	ctx = context.WithValue(context.Background(), api.ContextCredsKey{}, "badtoken")
 	req, err = apiv1.NewRequest(ctx, http.MethodPost, "/bar", data, nil)
 	require.NoError(t, err, "could not create request")
 	require.Empty(t, req.Header.Get("Authorization"), "expected the authorization header to be empty")

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -77,6 +77,34 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	_, err = apiv1.Do(req, nil, true)
 	require.EqualError(t, err, "[400] bad request")
+
+	// Test supplying an authentication override token in the request context
+	ctx := api.ContextWithToken(context.Background(), "newtoken")
+	req, err = apiv1.NewRequest(ctx, http.MethodPost, "/bar", data, nil)
+	require.NoError(t, err, "could not create request")
+	require.Equal(t, "Bearer newtoken", req.Header.Get("Authorization"), "expected the authorization header to be set")
+
+	// Test that malformed credentials in the request context are ignored
+	ctx = context.WithValue(context.Background(), api.ContextCreds, "badtoken")
+	req, err = apiv1.NewRequest(ctx, http.MethodPost, "/bar", data, nil)
+	require.NoError(t, err, "could not create request")
+	require.Empty(t, req.Header.Get("Authorization"), "expected the authorization header to be empty")
+
+	// Test that default credentials are used if no credentials are supplied in the request context
+	defaultCreds := api.Token("default")
+	client, err = api.New(ts.URL, api.WithCredentials(defaultCreds))
+	require.NoError(t, err, "could not create client")
+	apiv1, ok = client.(*api.APIv1)
+	require.True(t, ok, "could not cast client to APIv1")
+	req, err = apiv1.NewRequest(context.Background(), http.MethodPost, "/bar", data, nil)
+	require.NoError(t, err, "could not create request")
+	require.Equal(t, "Bearer default", req.Header.Get("Authorization"), "expected the authorization header to be set to default")
+
+	// Test that request credentials override default credentials
+	ctx = api.ContextWithToken(context.Background(), "newtoken")
+	req, err = apiv1.NewRequest(ctx, http.MethodPost, "/bar", data, nil)
+	require.NoError(t, err, "could not create request")
+	require.Equal(t, "Bearer newtoken", req.Header.Get("Authorization"), "expected the authorization header to be set to newtoken")
 }
 
 //===========================================================================

--- a/pkg/quarterdeck/middleware/auth_test.go
+++ b/pkg/quarterdeck/middleware/auth_test.go
@@ -148,12 +148,12 @@ func TestContextFromRequest(t *testing.T) {
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 
 	// Should error if there is no request on the context
-	ctx, err := middleware.ContextFromRequest(c)
+	_, err := middleware.ContextFromRequest(c)
 	require.ErrorIs(t, err, middleware.ErrNoRequest)
 
 	// Test when no access token is set
 	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
-	ctx, err = middleware.ContextFromRequest(c)
+	ctx, err := middleware.ContextFromRequest(c)
 	require.NoError(t, err, "could not get context from request")
 	require.NotNil(t, ctx, "no context was returned")
 	creds := api.CredsFromContext(ctx)

--- a/pkg/quarterdeck/middleware/auth_test.go
+++ b/pkg/quarterdeck/middleware/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/authtest"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
@@ -139,6 +140,34 @@ func TestGetAccessToken(t *testing.T) {
 	tks, err := middleware.GetAccessToken(c)
 	require.NoError(t, err)
 	require.Equal(t, "JWT", tks)
+}
+
+func TestContextFromRequest(t *testing.T) {
+	// Create a test context
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	// Should error if there is no request on the context
+	ctx, err := middleware.ContextFromRequest(c)
+	require.ErrorIs(t, err, middleware.ErrNoRequest)
+
+	// Test when no access token is set
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	ctx, err = middleware.ContextFromRequest(c)
+	require.NoError(t, err, "could not get context from request")
+	require.NotNil(t, ctx, "no context was returned")
+	creds := api.CredsFromContext(ctx)
+	require.Nil(t, creds, "credentials should not have been set")
+
+	// Test when an access token is set
+	c.Set(middleware.ContextAccessToken, "JWT")
+	ctx, err = middleware.ContextFromRequest(c)
+	require.NoError(t, err, "could not get context from request")
+	require.NotNil(t, ctx, "no context was returned")
+	creds = api.CredsFromContext(ctx)
+	token, err := creds.AccessToken()
+	require.NoError(t, err, "could not get access token from context")
+	require.Equal(t, "JWT", token, "access token was not set correctly")
 }
 
 func TestDefaultAuthOptions(t *testing.T) {

--- a/pkg/quarterdeck/middleware/errors.go
+++ b/pkg/quarterdeck/middleware/errors.go
@@ -16,4 +16,5 @@ var (
 	ErrCSRFVerification = errors.New("csrf verification failed for request")
 	ErrParseBearer      = errors.New("could not parse Bearer token from Authorization header")
 	ErrNoAuthorization  = errors.New("no authorization header in request")
+	ErrNoRequest        = errors.New("no request found on the context")
 )


### PR DESCRIPTION
### Scope of changes

This modifies the quarterdeck client and middleware to facilitate passthrough credentials. This approach uses the context that's passed through the client handlers and on the middleware side, the access token is initially passed through the gin context on `Authenticate` so it's available when the user of the quarterdeck client creates the request context.

Fixes SC-12797

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Implementors who are using the quarterdeck client (e.g. the tenant handlers) should be able to use the `ContextFromRequest` helper to create the request context with the authentication token in it in order to facilitate the passthrough.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.