### PR TITLE
Quarterdeck API Key Delete

### DIFF
--- a/pkg/quarterdeck/db/migrations/0001_initial_schema.sql
+++ b/pkg/quarterdeck/db/migrations/0001_initial_schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS api_keys (
     name                TEXT NOT NULL,
     organization_id     BLOB NOT NULL,
     project_id          BLOB NOT NULL,
-    created_by          BLOB DEFAULT NULL,
+    created_by          BLOB NOT NULL,
     source              TEXT DEFAULT NULL,
     user_agent          TEXT DEFAULT NULL,
     last_used           TEXT DEFAULT NULL,
@@ -49,6 +49,21 @@ CREATE TABLE IF NOT EXISTS api_keys (
     modified            TEXT NOT NULL,
     FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE SET NULL,
     FOREIGN KEY (created_by) REFERENCES users (id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS revoked_api_keys (
+    id                  BLOB PRIMARY KEY,
+    key_id              TEXT UNIQUE,
+    name                TEXT,
+    organization_id     BLOB,
+    project_id          BLOB,
+    created_by          BLOB,
+    source              TEXT DEFAULT NULL,
+    user_agent          TEXT DEFAULT NULL,
+    last_used           TEXT DEFAULT NULL,
+    permissions         TEXT DEFAULT NULL,
+    created             TEXT,
+    modified            TEXT
 );
 
 CREATE TABLE IF NOT EXISTS roles (

--- a/pkg/quarterdeck/quarterdeck_test.go
+++ b/pkg/quarterdeck/quarterdeck_test.go
@@ -151,8 +151,8 @@ func (s *quarterdeckTestSuite) ResetDatabase() (err error) {
 		"DELETE FROM organizations",
 		"DELETE FROM users",
 		"DELETE FROM organization_users",
-		"DELETE FROM projects",
 		"DELETE FROM api_keys",
+		"DELETE FROM revoked_api_keys",
 		"DELETE FROM user_roles",
 		"DELETE FROM api_key_permissions",
 	}


### PR DESCRIPTION
### Scope of changes

Implements the Quarterdeck API Key Delete endpoint as well as a models delete method that will only delete a key that matches an ID and organization. Created a revoked_api_keys database to store records of old api keys for auditing purposes. 

Fixes SC-12831

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review. 