### PR TITLE
Associate Organization and Project in Quarterdeck

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,3 +29,4 @@ Describe how reviewers can test this change to be sure that it works correctly. 
 ### Reviewer(s) checklist
 
 - [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
+- [ ] Are there any TODOs in this PR that should be turned into stories?

--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -30,6 +30,9 @@ type QuarterdeckClient interface {
 	APIKeyDetail(context.Context, string) (*APIKey, error)
 	APIKeyUpdate(context.Context, *APIKey) (*APIKey, error)
 	APIKeyDelete(context.Context, string) error
+
+	// Project Resource
+	ProjectCreate(context.Context, *Project) (*Project, error)
 }
 
 //===========================================================================
@@ -200,6 +203,28 @@ func (k *APIKey) ValidateUpdate() error {
 		return RestrictedField("last_used")
 	case len(k.Permissions) != 0:
 		return RestrictedField("permissions")
+	default:
+		return nil
+	}
+}
+
+//===========================================================================
+// Project Resource
+//===========================================================================
+
+type Project struct {
+	OrgID     ulid.ULID `json:"org_id,omitempty"`   // not allowed on create
+	ProjectID ulid.ULID `json:"project_id"`         // required on create
+	Created   time.Time `json:"created,omitempty"`  // cannot be edited
+	Modified  time.Time `json:"modified,omitempty"` // cannot be edited
+}
+
+func (p *Project) Validate() error {
+	switch {
+	case !ulids.IsZero(p.OrgID):
+		return RestrictedField("org_id")
+	case ulids.IsZero(p.ProjectID):
+		return MissingField("project_id")
 	default:
 		return nil
 	}

--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -220,6 +220,23 @@ func (s *APIv1) APIKeyDelete(ctx context.Context, id string) (err error) {
 }
 
 //===========================================================================
+// Project Resource
+//===========================================================================
+
+func (s *APIv1) ProjectCreate(ctx context.Context, in *Project) (out *Project, err error) {
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/projects", in, nil); err != nil {
+		return nil, err
+	}
+
+	if _, err = s.Do(req, &out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+//===========================================================================
 // Helper Methods
 //===========================================================================
 

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -335,6 +335,37 @@ func TestAPIKeyDelete(t *testing.T) {
 }
 
 //===========================================================================
+// Project Resource
+//===========================================================================
+
+func TestProjectCreate(t *testing.T) {
+	// Setup the response fixture
+	dts, _ := time.Parse(time.RFC3339Nano, time.Now().Format(time.RFC3339Nano))
+
+	fixture := &api.Project{
+		OrgID:     ulids.New(),
+		ProjectID: ulids.New(),
+		Created:   dts,
+		Modified:  dts,
+	}
+
+	// Create a test server
+	ts := httptest.NewServer(testhandler(fixture, http.MethodPost, "/v1/projects"))
+	defer ts.Close()
+
+	// Create a client and execute endpoint request
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create api client")
+
+	req := &api.Project{
+		ProjectID: fixture.ProjectID,
+	}
+	rep, err := client.ProjectCreate(context.TODO(), req)
+	require.NoError(t, err, "could not execute api request")
+	require.Equal(t, fixture, rep, "unexpected response returned")
+}
+
+//===========================================================================
 // Helper Methods
 //===========================================================================
 

--- a/pkg/quarterdeck/apikeys.go
+++ b/pkg/quarterdeck/apikeys.go
@@ -73,8 +73,7 @@ func (s *Server) APIKeyList(c *gin.Context) {
 		return
 	}
 
-	if orgID, err = ulid.Parse(claims.OrgID); err != nil {
-		c.Error(err)
+	if orgID = claims.ParseOrgID(); ulids.IsZero(orgID) {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse("user claims unavailable"))
 		return
 	}
@@ -193,15 +192,12 @@ func (s *Server) APIKeyCreate(c *gin.Context) {
 		return
 	}
 
-	if model.OrgID, err = ulid.Parse(claims.OrgID); err != nil {
-		c.Error(err)
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("invalid user claims"))
-		return
-	}
-
+	// NOTE: the OrgID and UserID MUST come from the user claims not from user input.
 	// NOTE: we expect that the subject of the claims is the userID.
-	if model.CreatedBy, err = ulid.Parse(claims.Subject); err != nil {
-		c.Error(err)
+	model.OrgID = claims.ParseOrgID()
+	model.CreatedBy = claims.ParseUserID()
+
+	if ulids.IsZero(model.OrgID) || ulids.IsZero(model.CreatedBy) {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse("invalid user claims"))
 		return
 	}
@@ -344,8 +340,7 @@ func (s *Server) APIKeyUpdate(c *gin.Context) {
 		Name: key.Name,
 	}
 
-	if model.OrgID, err = ulid.Parse(claims.OrgID); err != nil {
-		c.Error(err)
+	if model.OrgID = claims.ParseOrgID(); ulids.IsZero(model.OrgID) {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse("user claims unavailable"))
 		return
 	}
@@ -400,8 +395,7 @@ func (s *Server) APIKeyDelete(c *gin.Context) {
 		return
 	}
 
-	if orgID, err = ulid.Parse(claims.OrgID); err != nil {
-		c.Error(err)
+	if orgID = claims.ParseOrgID(); ulids.IsZero(orgID) {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse("user claims unavailable"))
 		return
 	}

--- a/pkg/quarterdeck/apikeys_test.go
+++ b/pkg/quarterdeck/apikeys_test.go
@@ -134,7 +134,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyCreate() {
 
 	rep, err := s.client.APIKeyCreate(ctx, req)
 	require.NoError(err, "could not execute happy path request")
-	require.NotEmpty(s, rep, "expected an API key response from the server")
+	require.NotEmpty(rep, "expected an API key response from the server")
 
 	// Validate the response returned by the server
 	require.False(ulids.IsZero(rep.ID), "no id returned in response")

--- a/pkg/quarterdeck/apikeys_test.go
+++ b/pkg/quarterdeck/apikeys_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
+	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
 )
@@ -36,7 +37,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyList() {
 	// Create valid claims for accessing the API
 	claims.Subject = "01GKHJSK7CZW0W282ZN3E9W86Z"
 	claims.OrgID = "01GKHJRF01YXHZ51YMMKV3RCMK"
-	claims.Permissions = []string{"apikeys:read"}
+	claims.Permissions = []string{perms.ReadAPIKeys}
 	ctx = s.AuthContext(ctx, claims)
 
 	// Should be able to list all keys for the specified organization
@@ -119,7 +120,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyCreate() {
 	// Create valid claims for accessing the API
 	claims.Subject = "01GKHJSK7CZW0W282ZN3E9W86Z"
 	claims.OrgID = "01GKHJRF01YXHZ51YMMKV3RCMK"
-	claims.Permissions = []string{"apikeys:edit"}
+	claims.Permissions = []string{perms.EditAPIKeys}
 	ctx = s.AuthContext(ctx, claims)
 
 	// TODO: test invalid requests
@@ -182,7 +183,7 @@ func (s *quarterdeckTestSuite) TestCannotCreateAPIKeyInUnownedProject() {
 		Name:        "Jannel P. Hudson",
 		Email:       "jannel@example.com",
 		OrgID:       "01GKHJRF01YXHZ51YMMKV3RCMK",
-		Permissions: []string{"apikeys:edit"},
+		Permissions: []string{perms.EditAPIKeys},
 	}
 	ctx = s.AuthContext(ctx, claims)
 
@@ -225,7 +226,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyDetail() {
 	s.CheckError(err, http.StatusUnauthorized, "user does not have permission to perform this operation")
 
 	// Cannot retrieve a key that is not in the same organization
-	claims.Permissions = []string{"apikeys:read"}
+	claims.Permissions = []string{perms.ReadAPIKeys}
 	ctx = s.AuthContext(ctx, claims)
 
 	apiKey, err = s.client.APIKeyDetail(ctx, "01GME02TJP2RRP39MKR525YDQ6")
@@ -241,7 +242,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyDetail() {
 		Email:       "jannel@example.com",
 		OrgID:       "01GKHJRF01YXHZ51YMMKV3RCMK",
 		ProjectID:   "01GQ7P8DNR9MR64RJR9D64FFNT",
-		Permissions: []string{"apikeys:read"},
+		Permissions: []string{perms.ReadAPIKeys},
 	}
 	ctx = s.AuthContext(ctx, claims)
 
@@ -302,7 +303,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyUpdate() {
 	require.Nil(out, "expected no data returned after an error")
 
 	// Cannot update a key that is not in the same organization
-	claims.Permissions = []string{"apikeys:edit"}
+	claims.Permissions = []string{perms.EditAPIKeys}
 	ctx = s.AuthContext(ctx, claims)
 	out, err = s.client.APIKeyUpdate(ctx, in)
 	s.CheckError(err, http.StatusNotFound, "api key not found")
@@ -367,7 +368,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyDelete() {
 	s.CheckError(err, http.StatusUnauthorized, "user does not have permission to perform this operation")
 
 	// Cannot delete a key that is not in the same organization
-	claims.Permissions = []string{"apikeys:delete"}
+	claims.Permissions = []string{perms.DeleteAPIKeys}
 	ctx = s.AuthContext(ctx, claims)
 	err = s.client.APIKeyDelete(ctx, "01GME02TJP2RRP39MKR525YDQ6")
 	s.CheckError(err, http.StatusNotFound, "api key not found")

--- a/pkg/quarterdeck/db/db.go
+++ b/pkg/quarterdeck/db/db.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"strings"
@@ -69,6 +70,12 @@ func Connect(dsn string, readonly bool) (err error) {
 		// Connect to the database
 		ro = readonly
 		if conn, err = sql.Open("sqlite3", uri.Path); err != nil {
+			return
+		}
+
+		// Ensure that foreign key support is turned on by executing PRAGMA query.
+		if _, err = conn.Exec("PRAGMA foreign_keys = on"); err != nil {
+			err = fmt.Errorf("could not enable foreign key support: %w", err)
 			return
 		}
 

--- a/pkg/quarterdeck/db/migrations/0001_initial_schema.sql
+++ b/pkg/quarterdeck/db/migrations/0001_initial_schema.sql
@@ -34,6 +34,15 @@ CREATE TABLE IF NOT EXISTS organization_users (
     FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
 );
 
+CREATE TABLE IF NOT EXISTS organization_projects (
+    organization_id     BLOB NOT NULL,
+    project_id          BLOB NOT NULL UNIQUE,
+    created             TEXT NOT NULL,
+    modified            TEXT NOT NULL,
+    PRIMARY KEY (organization_id, project_id),
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS api_keys (
     id                  BLOB PRIMARY KEY,
     key_id              TEXT NOT NULL UNIQUE,

--- a/pkg/quarterdeck/db/migrations/0001_initial_schema.sql
+++ b/pkg/quarterdeck/db/migrations/0001_initial_schema.sql
@@ -56,8 +56,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
     last_used           TEXT DEFAULT NULL,
     created             TEXT NOT NULL,
     modified            TEXT NOT NULL,
-    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE SET NULL,
-    FOREIGN KEY (created_by) REFERENCES users (id) ON DELETE SET NULL
+    FOREIGN KEY (organization_id) REFERENCES organizations (id) ON DELETE RESTRICT,
+    FOREIGN KEY (created_by) REFERENCES users (id) ON DELETE RESTRICT
 );
 
 CREATE TABLE IF NOT EXISTS revoked_api_keys (

--- a/pkg/quarterdeck/db/models/apikeys.go
+++ b/pkg/quarterdeck/db/models/apikeys.go
@@ -184,7 +184,6 @@ func GetAPIKey(ctx context.Context, clientID string) (key *APIKey, err error) {
 	if err = tx.Commit(); err != nil {
 		return nil, err
 	}
-
 	return key, nil
 }
 

--- a/pkg/quarterdeck/db/models/apikeys_test.go
+++ b/pkg/quarterdeck/db/models/apikeys_test.go
@@ -191,6 +191,7 @@ func (m *modelTestSuite) TestCreateAPIKey() {
 		Name:      "Testing API Key",
 		OrgID:     ulid.MustParse("01GKHJRF01YXHZ51YMMKV3RCMK"),
 		ProjectID: ulid.MustParse("01GQ7P8DNR9MR64RJR9D64FFNT"),
+		CreatedBy: ulid.MustParse("01GKHJSK7CZW0W282ZN3E9W86Z"),
 	}
 	apikey.SetPermissions("publisher", "subscriber")
 
@@ -320,6 +321,9 @@ func (m *modelTestSuite) TestAPIKeyValidation() {
 
 	// Permissions are required
 	apikey.ProjectID = ulids.New()
+	require.ErrorIs(apikey.Validate(), models.ErrMissingCreatedBy)
+
+	apikey.CreatedBy = ulids.New()
 	require.ErrorIs(apikey.Validate(), models.ErrNoPermissions)
 
 	// Valid API Key

--- a/pkg/quarterdeck/db/models/apikeys_test.go
+++ b/pkg/quarterdeck/db/models/apikeys_test.go
@@ -190,7 +190,7 @@ func (m *modelTestSuite) TestCreateAPIKey() {
 	apikey := &models.APIKey{
 		Name:      "Testing API Key",
 		OrgID:     ulid.MustParse("01GKHJRF01YXHZ51YMMKV3RCMK"),
-		ProjectID: ulids.New(),
+		ProjectID: ulid.MustParse("01GQ7P8DNR9MR64RJR9D64FFNT"),
 	}
 	apikey.SetPermissions("publisher", "subscriber")
 
@@ -213,6 +213,11 @@ func (m *modelTestSuite) TestCreateAPIKey() {
 	expectedPermissions, _ := apikey.Permissions(context.Background(), false)
 	actualPermissions, _ := apikey.Permissions(context.Background(), false)
 	require.Equal(expectedPermissions, actualPermissions, "permissions not saved to database")
+
+	// Should not be able to create an APIKey for a project not associated with the orgID
+	apikey.OrgID = ulid.MustParse("01GQFQ14HXF2VC7C1HJECS60XX")
+	err = apikey.Create(context.Background())
+	require.ErrorIs(err, models.ErrInvalidProjectID)
 }
 
 func (m *modelTestSuite) TestUpdateAPIKey() {

--- a/pkg/quarterdeck/db/models/errors.go
+++ b/pkg/quarterdeck/db/models/errors.go
@@ -19,12 +19,14 @@ var (
 	ErrMissingProjectID   = errors.New("model requires project id")
 	ErrInvalidProjectID   = errors.New("invalid project id for apikey")
 	ErrMissingKeyName     = errors.New("apikey model requires name")
+	ErrMissingCreatedBy   = errors.New("apikey model requires created by")
 	ErrNoPermissions      = errors.New("apikey model requires permissions")
 	ErrModifyPermissions  = errors.New("cannot modify permissions on an existing APIKey object")
 	ErrMissingPageSize    = errors.New("cannot list database without a page size")
 	ErrInvalidCursor      = errors.New("could not compute the next page of results")
 	ErrDuplicate          = errors.New("unique constraint violated on model")
 	ErrMissingRelation    = errors.New("foreign key relation violated on model")
+	ErrNotNull            = errors.New("not null constraint violated on model")
 	ErrConstraint         = errors.New("database constraint violated")
 )
 
@@ -62,6 +64,8 @@ func constraint(dberr sqlite3.Error) *ConstraintError {
 		return &ConstraintError{err: ErrDuplicate, dberr: dberr}
 	case strings.HasPrefix(errs, "FOREIGN KEY"):
 		return &ConstraintError{err: ErrMissingRelation, dberr: dberr}
+	case strings.HasPrefix(errs, "NOT NULL"):
+		return &ConstraintError{err: ErrNotNull, dberr: dberr}
 	default:
 		return &ConstraintError{err: ErrConstraint, dberr: dberr}
 	}

--- a/pkg/quarterdeck/db/models/errors.go
+++ b/pkg/quarterdeck/db/models/errors.go
@@ -3,6 +3,9 @@ package models
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/mattn/go-sqlite3"
 )
 
 var (
@@ -13,13 +16,16 @@ var (
 	ErrMissingKeyMaterial = errors.New("apikey model requires client id and secret")
 	ErrInvalidSecret      = errors.New("apikey secrets should be stored as argon2 derived keys")
 	ErrMissingOrgID       = errors.New("model does not have an organization ID assigned")
-	ErrMissingProjectID   = errors.New("apikey model requires project id")
+	ErrMissingProjectID   = errors.New("model requires project id")
 	ErrInvalidProjectID   = errors.New("invalid project id for apikey")
 	ErrMissingKeyName     = errors.New("apikey model requires name")
 	ErrNoPermissions      = errors.New("apikey model requires permissions")
 	ErrModifyPermissions  = errors.New("cannot modify permissions on an existing APIKey object")
 	ErrMissingPageSize    = errors.New("cannot list database without a page size")
 	ErrInvalidCursor      = errors.New("could not compute the next page of results")
+	ErrDuplicate          = errors.New("unique constraint violated on model")
+	ErrMissingRelation    = errors.New("foreign key relation violated on model")
+	ErrConstraint         = errors.New("database constraint violated")
 )
 
 type ValidationError struct {
@@ -39,5 +45,39 @@ func (e *ValidationError) Is(target error) bool {
 }
 
 func (e *ValidationError) Unwrap() error {
+	return e.err
+}
+
+// ConstraintError attempts to parse a sqlite3.ErrConstraint error into a model error.
+type ConstraintError struct {
+	err   error
+	dberr sqlite3.Error
+}
+
+func constraint(dberr sqlite3.Error) *ConstraintError {
+	// String parsing seems to be the only way to deal with error handling for sqlite3
+	errs := dberr.Error()
+	switch {
+	case strings.HasPrefix(errs, "UNIQUE"):
+		return &ConstraintError{err: ErrDuplicate, dberr: dberr}
+	case strings.HasPrefix(errs, "FOREIGN KEY"):
+		return &ConstraintError{err: ErrMissingRelation, dberr: dberr}
+	default:
+		return &ConstraintError{err: ErrConstraint, dberr: dberr}
+	}
+}
+
+func (e *ConstraintError) Error() string {
+	if e.dberr.Code == sqlite3.ErrConstraint {
+		return e.err.Error()
+	}
+	return e.dberr.Error()
+}
+
+func (e *ConstraintError) Is(target error) bool {
+	return errors.Is(e.err, target)
+}
+
+func (e *ConstraintError) Unwrap() error {
 	return e.err
 }

--- a/pkg/quarterdeck/db/models/errors.go
+++ b/pkg/quarterdeck/db/models/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrInvalidSecret      = errors.New("apikey secrets should be stored as argon2 derived keys")
 	ErrMissingOrgID       = errors.New("model does not have an organization ID assigned")
 	ErrMissingProjectID   = errors.New("apikey model requires project id")
+	ErrInvalidProjectID   = errors.New("invalid project id for apikey")
 	ErrMissingKeyName     = errors.New("apikey model requires name")
 	ErrNoPermissions      = errors.New("apikey model requires permissions")
 	ErrModifyPermissions  = errors.New("cannot modify permissions on an existing APIKey object")

--- a/pkg/quarterdeck/db/models/orgs.go
+++ b/pkg/quarterdeck/db/models/orgs.go
@@ -63,7 +63,7 @@ func GetOrg(ctx context.Context, orgID ulid.ULID) (org *Organization, err error)
 	if err = tx.Commit(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	return org, nil
 }
 
 // Exists checks if an organization project mapping exists in order to verify that a

--- a/pkg/quarterdeck/db/models/orgs.go
+++ b/pkg/quarterdeck/db/models/orgs.go
@@ -1,6 +1,13 @@
 package models
 
-import "github.com/oklog/ulid/v2"
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/db"
+)
 
 // Organization is a model that represents a row in the organizations table and provides
 // database functionality for interacting with an organizations's data. It should not be
@@ -19,4 +26,72 @@ type OrganizationUser struct {
 	Base
 	OrgID  ulid.ULID
 	UserID ulid.ULID
+}
+
+// OrganizationProject is a model representing the many-to-one mapping between projects
+// and organizations. The project model is not stored in the database (but rather in
+// the tenant database) so only the projectID is stored, but it must be unique to
+// prevent a security hole where a user issues APIKeys to a project in an organization
+// that they do not belong to. Before issuing APIKeys with a projectID, Quarterdeck
+// checks to ensure that the project actually belongs to the organization via a lookup
+// in this table. Otherwise, all information about the project is stored in Tenant.
+type OrganizationProject struct {
+	Base
+	OrgID     ulid.ULID
+	ProjectID ulid.ULID
+}
+
+const (
+	getOrgSQL = "SELECT name, domain, created, modified FROM organizations WHERE id=:id"
+)
+
+func GetOrg(ctx context.Context, orgID ulid.ULID) (org *Organization, err error) {
+	org = &Organization{ID: orgID}
+	var tx *sql.Tx
+	if tx, err = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	if err = tx.QueryRow(getOrgSQL, sql.Named("id", org.ID)).Scan(&org.Name, &org.Domain, &org.Created, &org.Modified); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// Exists checks if an organization project mapping exists in order to verify that a
+// project is allowed to be associated with an APIKey or other claims resource for the
+// user with the specified OrgID claims. Only the OrgID and ProjectID are used for this
+// so no preliminary fetch from the database is required to execute the query.
+func (op *OrganizationProject) Exists(ctx context.Context) (ok bool, err error) {
+	var tx *sql.Tx
+	if tx, err = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	if ok, err = op.exists(tx); err != nil {
+		return ok, err
+	}
+	tx.Commit()
+	return ok, err
+}
+
+const (
+	orgProjExistsSQL = "SELECT EXISTS(SELECT 1 FROM organization_projects WHERE organization_id=:orgID AND project_id=:projectID);"
+)
+
+// Check if a project is associated with an organization inside of a transaction.
+func (op *OrganizationProject) exists(tx *sql.Tx) (ok bool, err error) {
+	if err = tx.QueryRow(orgProjExistsSQL, sql.Named("orgID", op.OrgID), sql.Named("projectID", op.ProjectID)).Scan(&ok); err != nil {
+		return false, err
+	}
+	return ok, nil
 }

--- a/pkg/quarterdeck/db/models/orgs_test.go
+++ b/pkg/quarterdeck/db/models/orgs_test.go
@@ -1,0 +1,59 @@
+package models_test
+
+import (
+	"context"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
+	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/stretchr/testify/require"
+)
+
+func (m *modelTestSuite) TestGetOrg() {
+	require := m.Require()
+	ctx := context.Background()
+
+	// Ensure GetOrg returns not found error
+	org, err := models.GetOrg(ctx, ulids.New())
+	require.ErrorIs(err, models.ErrNotFound)
+	require.Nil(org)
+
+	org, err = models.GetOrg(ctx, ulid.MustParse("01GKHJRF01YXHZ51YMMKV3RCMK"))
+	require.NoError(err, "could not fetch organization from database")
+
+	// Ensure model is fully populated
+	require.Equal("01GKHJRF01YXHZ51YMMKV3RCMK", org.ID.String())
+	require.Equal("Testing", org.Name)
+	require.Equal("example.com", org.Domain)
+	require.NotEmpty(org.Created, "no created timestamp")
+	require.NotEmpty(org.Modified, "no modified timestamp")
+}
+
+func (m *modelTestSuite) TestOrganizationProjectExists() {
+	nullULID := ulids.Null.String()
+	testCases := []struct {
+		OrgID, ProjectID string
+		Exists           require.BoolAssertionFunc
+	}{
+		{nullULID, nullULID, require.False},
+		{"01GKHJRF01YXHZ51YMMKV3RCMK", nullULID, require.False},
+		{nullULID, "01GQ7P8DNR9MR64RJR9D64FFNT", require.False},
+		{"01GKHJRF01YXHZ51YMMKV3RCMK", "01GQ7P8DNR9MR64RJR9D64FFNT", require.True},
+		{"01GQFQ14HXF2VC7C1HJECS60XX", "01GQFQCFC9P3S7QZTPYFVBJD7F", require.True},
+		{"01GKHJRF01YXHZ51YMMKV3RCMK", "01GQFQCFC9P3S7QZTPYFVBJD7F", require.False},
+		{"01GQFQ14HXF2VC7C1HJECS60XX", "01GQ7P8DNR9MR64RJR9D64FFNT", require.False},
+		{ulids.New().String(), "01GQ7P8DNR9MR64RJR9D64FFNT", require.False},
+		{"01GQFQ14HXF2VC7C1HJECS60XX", ulids.New().String(), require.False},
+		{ulids.New().String(), ulids.New().String(), require.False},
+	}
+
+	for i, tc := range testCases {
+		op := &models.OrganizationProject{
+			OrgID:     ulid.MustParse(tc.OrgID),
+			ProjectID: ulid.MustParse(tc.ProjectID),
+		}
+		ok, err := op.Exists(context.Background())
+		require.NoError(m.T(), err, "test case %d failed", i)
+		tc.Exists(m.T(), ok, "unexpected response from database")
+	}
+}

--- a/pkg/quarterdeck/db/models/testdata/fixtures.sql
+++ b/pkg/quarterdeck/db/models/testdata/fixtures.sql
@@ -19,6 +19,12 @@ INSERT INTO organization_users (organization_id, user_id, created, modified) VAL
     (x'0185df70923d78b6c3b03193999303bd', x'0185df7210e5d8d7f6d33d7ecad99bbd', '2023-01-23T16:24:32.741955Z', '2023-01-23T16:24:32.741955Z')
 ;
 
+INSERT INTO organization_projects (organization_id, project_id, created, modified) VALUES
+    (x'0184e32c3c01f763f287d4a4f63c3293', x'0185cf6436b84d306262584b4c47beba', '2022-12-05T16:43:57.825256Z', '2022-12-05T16:43:57.825256Z'),
+    (x'0184e32c3c01f763f287d4a4f63c3293', x'0185df804e85c8b399220570106ddd33', '2022-12-05T16:43:57.825256Z', '2022-12-05T16:43:57.825256Z'),
+    (x'0185df70923d78b6c3b03193999303bd', x'0185df763d89b0f27bff56f3f6b934ef', '2023-01-23T16:22:54.781762Z', '2023-01-23T16:22:54.781762Z')
+;
+
 INSERT INTO user_roles (user_id, role_id, created, modified) VALUES
     (x'0184e32cccecff01c1205fa8dc9e20df', 1, '2022-12-05T16:44:35.00123Z', '2022-12-05T16:44:35.00123Z'),
     (x'0185df7210e5d8d7f6d33d7ecad99bbd', 1, '2023-01-23T16:24:32.741955Z', '2023-01-23T16:24:32.741955Z')

--- a/pkg/quarterdeck/orgs.go
+++ b/pkg/quarterdeck/orgs.go
@@ -1,0 +1,65 @@
+package quarterdeck
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+)
+
+func (s *Server) ProjectCreate(c *gin.Context) {
+	var (
+		err     error
+		project *api.Project
+		claims  *tokens.Claims
+	)
+
+	// Bind the Project request to the project data structure
+	if err = c.BindJSON(&project); err != nil {
+		c.Error(err)
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse request"))
+		return
+	}
+
+	// Validate the request from the API side.
+	if err = project.Validate(); err != nil {
+		c.Error(err)
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		return
+	}
+
+	// Fetch the user claims from the request
+	if claims, err = middleware.GetClaims(c); err != nil {
+		c.Error(err)
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("user claims unavailable"))
+		return
+	}
+
+	// Create the OrganizationProjects mapping database model
+	model := &models.OrganizationProject{
+		OrgID:     claims.ParseOrgID(),
+		ProjectID: project.ProjectID,
+	}
+
+	// Save the model to the database
+	if err = model.Save(c.Request.Context()); err != nil {
+		c.Error(err)
+		switch err.(type) {
+		case *models.ValidationError:
+			c.JSON(http.StatusBadRequest, api.ErrorResponse(err))
+		default:
+			c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not create project"))
+		}
+		return
+	}
+
+	// Update the response to send to the user
+	project.OrgID = model.OrgID
+	project.ProjectID = model.ProjectID
+	project.Created, _ = model.GetCreated()
+	project.Modified, _ = model.GetModified()
+	c.JSON(http.StatusOK, project)
+}

--- a/pkg/quarterdeck/orgs_test.go
+++ b/pkg/quarterdeck/orgs_test.go
@@ -1,0 +1,60 @@
+package quarterdeck_test
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
+	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+)
+
+func (s *quarterdeckTestSuite) TestProjectCreate() {
+	require := s.Require()
+	defer s.ResetDatabase()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Creating a project requires authentication
+	req := &api.Project{ProjectID: ulids.New()}
+	_, err := s.client.ProjectCreate(ctx, req)
+	s.CheckError(err, http.StatusUnauthorized, "this endpoint requires authentication")
+
+	// Creating an Project requires the projects:edit permission
+	claims := &tokens.Claims{
+		Name:  "Jannel P. Hudson",
+		Email: "jannel@example.com",
+	}
+	ctx = s.AuthContext(ctx, claims)
+
+	_, err = s.client.ProjectCreate(ctx, req)
+	s.CheckError(err, http.StatusUnauthorized, "user does not have permission to perform this operation")
+
+	// Create valid claims for accessing the API
+	claims.Subject = "01GKHJSK7CZW0W282ZN3E9W86Z"
+	claims.OrgID = "01GKHJRF01YXHZ51YMMKV3RCMK"
+	claims.Permissions = []string{perms.EditProjects}
+	ctx = s.AuthContext(ctx, claims)
+
+	// Test Happy Path
+	rep, err := s.client.ProjectCreate(ctx, req)
+	require.NoError(err, "could not create project after authentication")
+	require.NotEmpty(rep, "expected a project response from the server")
+
+	// Validate the response returned by the server
+	require.False(ulids.IsZero(rep.OrgID), "no orgID returned in response")
+	require.Equal(req.ProjectID, rep.ProjectID, "expected project id to be identical in response")
+	require.False(rep.Created.IsZero(), "no created returned in response")
+	require.False(rep.Modified.IsZero(), "no modified returned in response")
+
+	// Must specify a projectID
+	_, err = s.client.ProjectCreate(ctx, &api.Project{})
+	s.CheckError(err, http.StatusBadRequest, "missing required field: project_id")
+
+	// Cannot specify an orgID
+	_, err = s.client.ProjectCreate(ctx, &api.Project{OrgID: ulids.New(), ProjectID: ulids.New()})
+	s.CheckError(err, http.StatusBadRequest, "field restricted for request: org_id")
+}

--- a/pkg/quarterdeck/quarterdeck.go
+++ b/pkg/quarterdeck/quarterdeck.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/config"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
+	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/utils/logger"
 	"github.com/rotationalio/ensign/pkg/utils/sentry"
@@ -261,11 +262,17 @@ func (s *Server) setupRoutes() (err error) {
 		// API Keys Resource
 		apikeys := v1.Group("/apikeys", authenticate)
 		{
-			apikeys.GET("", middleware.Authorize("apikeys:read"), s.APIKeyList)
-			apikeys.POST("", middleware.Authorize("apikeys:edit"), s.APIKeyCreate)
-			apikeys.GET("/:id", middleware.Authorize("apikeys:read"), s.APIKeyDetail)
-			apikeys.PUT("/:id", middleware.Authorize("apikeys:edit"), s.APIKeyUpdate)
-			apikeys.DELETE("/:id", middleware.Authorize("apikeys:delete"), s.APIKeyDelete)
+			apikeys.GET("", middleware.Authorize(perms.ReadAPIKeys), s.APIKeyList)
+			apikeys.POST("", middleware.Authorize(perms.EditAPIKeys), s.APIKeyCreate)
+			apikeys.GET("/:id", middleware.Authorize(perms.ReadAPIKeys), s.APIKeyDetail)
+			apikeys.PUT("/:id", middleware.Authorize(perms.EditAPIKeys), s.APIKeyUpdate)
+			apikeys.DELETE("/:id", middleware.Authorize(perms.DeleteAPIKeys), s.APIKeyDelete)
+		}
+
+		// Projects Resource
+		projects := v1.Group("/projects", authenticate)
+		{
+			projects.POST("", middleware.Authorize(perms.EditProjects), s.ProjectCreate)
 		}
 	}
 

--- a/pkg/quarterdeck/quarterdeck_test.go
+++ b/pkg/quarterdeck/quarterdeck_test.go
@@ -152,15 +152,16 @@ func (s *quarterdeckTestSuite) ResetDatabase() {
 
 func (s *quarterdeckTestSuite) resetDatabase() (err error) {
 	// Truncate all database tables except roles, permissions, and role_permissions
+	// NOTE: Ensure that we delete tables in the order of foreign key relationships
 	stmts := []string{
-		"DELETE FROM organizations",
-		"DELETE FROM users",
+		"DELETE FROM revoked_api_keys",
+		"DELETE FROM api_key_permissions",
+		"DELETE FROM api_keys",
 		"DELETE FROM organization_users",
 		"DELETE FROM organization_projects",
-		"DELETE FROM api_keys",
-		"DELETE FROM revoked_api_keys",
+		"DELETE FROM organizations",
 		"DELETE FROM user_roles",
-		"DELETE FROM api_key_permissions",
+		"DELETE FROM users",
 	}
 
 	var tx *sql.Tx

--- a/pkg/quarterdeck/quarterdeck_test.go
+++ b/pkg/quarterdeck/quarterdeck_test.go
@@ -156,6 +156,7 @@ func (s *quarterdeckTestSuite) resetDatabase() (err error) {
 		"DELETE FROM organizations",
 		"DELETE FROM users",
 		"DELETE FROM organization_users",
+		"DELETE FROM organization_projects",
 		"DELETE FROM api_keys",
 		"DELETE FROM revoked_api_keys",
 		"DELETE FROM user_roles",

--- a/pkg/quarterdeck/testdata/fixtures.sql
+++ b/pkg/quarterdeck/testdata/fixtures.sql
@@ -19,6 +19,12 @@ INSERT INTO organization_users (organization_id, user_id, created, modified) VAL
     (x'0185df70923d78b6c3b03193999303bd', x'0185df7210e5d8d7f6d33d7ecad99bbd', '2023-01-23T16:24:32.741955Z', '2023-01-23T16:24:32.741955Z')
 ;
 
+INSERT INTO organization_projects (organization_id, project_id, created, modified) VALUES
+    (x'0184e32c3c01f763f287d4a4f63c3293', x'0185cf6436b84d306262584b4c47beba', '2022-12-05T16:43:57.825256Z', '2022-12-05T16:43:57.825256Z'),
+    (x'0184e32c3c01f763f287d4a4f63c3293', x'0185df804e85c8b399220570106ddd33', '2022-12-05T16:43:57.825256Z', '2022-12-05T16:43:57.825256Z'),
+    (x'0185df70923d78b6c3b03193999303bd', x'0185df763d89b0f27bff56f3f6b934ef', '2023-01-23T16:22:54.781762Z', '2023-01-23T16:22:54.781762Z')
+;
+
 INSERT INTO user_roles (user_id, role_id, created, modified) VALUES
     (x'0184e32cccecff01c1205fa8dc9e20df', 1, '2022-12-05T16:44:35.00123Z', '2022-12-05T16:44:35.00123Z'),
     (x'0185df7210e5d8d7f6d33d7ecad99bbd', 1, '2023-01-23T16:24:32.741955Z', '2023-01-23T16:24:32.741955Z')

--- a/pkg/quarterdeck/tokens/claims.go
+++ b/pkg/quarterdeck/tokens/claims.go
@@ -48,7 +48,7 @@ func (c Claims) ParseOrgID() ulid.ULID {
 	return orgID
 }
 
-// ParseUserID reteurns the ULID of the user from the Subject of the claims. If the
+// ParseUserID returns the ULID of the user from the Subject of the claims. If the
 // UserID is not valid then an empty ULID is returned without an error to reduce error
 // checking in the handlers. If the caller needs to know if the ULID is invalid, they
 // should parse it themsleves or perform an IsZero check on the result.

--- a/pkg/quarterdeck/tokens/claims.go
+++ b/pkg/quarterdeck/tokens/claims.go
@@ -47,3 +47,15 @@ func (c Claims) ParseOrgID() ulid.ULID {
 	}
 	return orgID
 }
+
+// ParseUserID reteurns the ULID of the user from the Subject of the claims. If the
+// UserID is not valid then an empty ULID is returned without an error to reduce error
+// checking in the handlers. If the caller needs to know if the ULID is invalid, they
+// should parse it themsleves or perform an IsZero check on the result.
+func (c Claims) ParseUserID() ulid.ULID {
+	userID, err := ulid.Parse(c.Subject)
+	if err != nil {
+		return ulids.Null
+	}
+	return userID
+}

--- a/pkg/quarterdeck/tokens/claims.go
+++ b/pkg/quarterdeck/tokens/claims.go
@@ -1,6 +1,10 @@
 package tokens
 
-import jwt "github.com/golang-jwt/jwt/v4"
+import (
+	jwt "github.com/golang-jwt/jwt/v4"
+	"github.com/oklog/ulid/v2"
+	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+)
 
 // Claims implements custom claims for the Quarterdeck application.
 type Claims struct {
@@ -30,4 +34,16 @@ func (c Claims) HasAllPermissions(requiredPermissions ...string) bool {
 		}
 	}
 	return true
+}
+
+// ParseOrgID returns the ULID of the organization ID in the claims. If the OrgID is not
+// valid then an empty ULID is returned without an error to reduce error checking in
+// handlers. If the caller needs to know if the ULID is invalid they should parse it
+// themselves; otherwise the Null ULID will prevent most accesses from succeeding.
+func (c Claims) ParseOrgID() ulid.ULID {
+	orgID, err := ulid.Parse(c.OrgID)
+	if err != nil {
+		return ulids.Null
+	}
+	return orgID
 }

--- a/pkg/quarterdeck/tokens/claims_test.go
+++ b/pkg/quarterdeck/tokens/claims_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
+	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,4 +19,16 @@ func TestClaims(t *testing.T) {
 	require.False(t, claims.HasAllPermissions("write:foo", "write:bar"), "only has one permission")
 	require.False(t, claims.HasAllPermissions("delete:bar", "write:bar"), "has no permissions")
 	require.True(t, claims.HasAllPermissions("delete:foo", "write:foo", "read:foo"), "has all permissions")
+}
+
+func TestClaimsParseOrgID(t *testing.T) {
+	claims := &tokens.Claims{}
+	require.Equal(t, ulids.Null, claims.ParseOrgID())
+
+	claims.OrgID = "notvalid"
+	require.Equal(t, ulids.Null, claims.ParseOrgID())
+
+	orgID := ulids.New()
+	claims.OrgID = orgID.String()
+	require.Equal(t, orgID, claims.ParseOrgID())
 }

--- a/pkg/quarterdeck/tokens/claims_test.go
+++ b/pkg/quarterdeck/tokens/claims_test.go
@@ -32,3 +32,15 @@ func TestClaimsParseOrgID(t *testing.T) {
 	claims.OrgID = orgID.String()
 	require.Equal(t, orgID, claims.ParseOrgID())
 }
+
+func TestClaimsParseUserID(t *testing.T) {
+	claims := &tokens.Claims{}
+	require.Equal(t, ulids.Null, claims.ParseUserID())
+
+	claims.Subject = "notvalid"
+	require.Equal(t, ulids.Null, claims.ParseUserID())
+
+	userID := ulids.New()
+	claims.Subject = userID.String()
+	require.Equal(t, userID, claims.ParseUserID())
+}


### PR DESCRIPTION
### Scope of changes

Adds an endpoint for Tenant to associate an organization and a project in Quarterdeck so that Quarterdeck can securely issue APIKeys for a project, verifying that the project belongs to the Organization in the claims of the requester.

Fixes SC-13077

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Is there anything Tenant needs other than what's here? 

Are these utilities usable for Tenant and does it close the security hole?

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.