### PR TITLE
Fix hugo examples idx page ref link

### DIFF
--- a/docs/content/examples/_index.md
+++ b/docs/content/examples/_index.md
@@ -12,4 +12,4 @@ bookSearchExclude: false
 
 This section of the documentation provides end-to-end examples using Ensign to help get you started!
 
-- [Ensign for Application Developers](({{< relref "examples/developers" >}})): In this end-to-end example, see how to curate a custom Twitter feed using Ensign. Create a publisher to start emitting tweets to a topic stream in just a few minutes! See how to create one or more asynchronous subscribers that can read off the stream and process the data as needed.
+- [Ensign for Application Developers]({{< ref "/examples/developers" >}}): In this end-to-end example, see how to curate a custom Twitter feed using Ensign. Create a publisher to start emitting tweets to a topic stream in just a few minutes! See how to create one or more asynchronous subscribers that can read off the stream and process the data as needed.


### PR DESCRIPTION
This PR repairs the incorrect ref link I injected between the e-2-e examples index page and Patrick's example. 