### PR TITLE
Tenant Project API key security checks

### DIFF
--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -9,7 +9,9 @@ import (
 	"github.com/oklog/ulid/v2"
 	qd "github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
+	"github.com/rotationalio/ensign/pkg/tenant/db"
 	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
 	"github.com/rs/zerolog/log"
 )
@@ -20,14 +22,22 @@ import (
 // Route: GET /v1/projects/:projectID/apikeys
 func (s *Server) ProjectAPIKeyList(c *gin.Context) {
 	var (
-		ctx context.Context
-		err error
+		claims *tokens.Claims
+		ctx    context.Context
+		err    error
 	)
 
 	// User credentials are required to make the Quarterdeck request
 	if ctx, err = middleware.ContextFromRequest(c); err != nil {
 		log.Error().Err(err).Msg("could not create user context from request")
 		c.JSON(http.StatusUnauthorized, api.ErrorResponse("could not fetch credentials for authenticated user"))
+		return
+	}
+
+	// User claims are required to check ownership of the project
+	if claims, err = middleware.GetClaims(c); err != nil {
+		log.Error().Err(err).Msg("could not get user claims from context")
+		c.JSON(http.StatusUnauthorized, api.ErrorResponse("could not fetch claims for authenticated user"))
 		return
 	}
 
@@ -39,12 +49,33 @@ func (s *Server) ProjectAPIKeyList(c *gin.Context) {
 		return
 	}
 
-	// TODO: Validate that the user is associated with the project by checking the
-	// orgID in the claims against the orgID in the project.
+	// Parse the project ID from the URL
+	paramID := c.Param("projectID")
+	var projectID ulid.ULID
+	if projectID, err = ulids.Parse(paramID); err != nil {
+		log.Warn().Str("id", paramID).Err(err).Msg("could not parse project id")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse project id"))
+		return
+	}
+
+	// Retrieve the project from the database
+	var project *db.Project
+	if project, err = db.RetrieveProject(ctx, projectID); err != nil {
+		log.Error().Str("id", paramID).Err(err).Msg("could not retrieve project from database")
+		c.JSON(http.StatusNotFound, api.ErrorResponse("project not found"))
+		return
+	}
+
+	// User should not be able to list API keys in another organization
+	if claims.OrgID != project.OrgID.String() {
+		log.Warn().Str("user_org", claims.OrgID).Str("project_org", project.OrgID.String()).Msg("user cannot list API keys in this project")
+		c.JSON(http.StatusForbidden, api.ErrorResponse("user is not authorized to access this project"))
+		return
+	}
 
 	// Build the Quarterdeck request from the params
 	req := &qd.APIPageQuery{
-		ProjectID:     c.Param("projectID"),
+		ProjectID:     paramID,
 		PageSize:      int(params.PageSize),
 		NextPageToken: params.NextPageToken,
 	}
@@ -82,14 +113,22 @@ func (s *Server) ProjectAPIKeyList(c *gin.Context) {
 // Route: POST /v1/projects/:projectID/apikeys
 func (s *Server) ProjectAPIKeyCreate(c *gin.Context) {
 	var (
-		ctx context.Context
-		err error
+		claims *tokens.Claims
+		ctx    context.Context
+		err    error
 	)
 
 	// User credentials are required to make the Quarterdeck request
 	if ctx, err = middleware.ContextFromRequest(c); err != nil {
 		log.Error().Err(err).Msg("could not create user context from request")
 		c.JSON(http.StatusUnauthorized, api.ErrorResponse("could not fetch credentials for authenticated user"))
+		return
+	}
+
+	// User claims are required to check ownership of the project
+	if claims, err = middleware.GetClaims(c); err != nil {
+		log.Error().Err(err).Msg("could not get user claims from context")
+		c.JSON(http.StatusUnauthorized, api.ErrorResponse("could not fetch claims for authenticated user"))
 		return
 	}
 
@@ -128,8 +167,20 @@ func (s *Server) ProjectAPIKeyCreate(c *gin.Context) {
 		return
 	}
 
-	// TODO: Validate that the user is associated with the project by checking the
-	// orgID in the claims against the project's orgID
+	// Retrieve the Project from the database
+	var project *db.Project
+	if project, err = db.RetrieveProject(ctx, req.ProjectID); err != nil {
+		log.Error().Err(err).Str("projectID", projectID).Msg("could not retrieve project from database")
+		c.JSON(http.StatusNotFound, api.ErrorResponse("project not found"))
+		return
+	}
+
+	// User should not be able to create API keys in another organization
+	if claims.OrgID != project.OrgID.String() {
+		log.Warn().Str("user_org", claims.OrgID).Str("project_org", project.OrgID.String()).Msg("user cannot create API keys in this project")
+		c.JSON(http.StatusForbidden, api.ErrorResponse("user is not authorized to access this project"))
+		return
+	}
 
 	// TODO: Add source to request
 


### PR DESCRIPTION
### Scope of changes

This adds a security check to the `ProjectAPIKeyCreate` and `ProjectAPIKeyList` Tenant handlers to ensure that the user is allowed to access the project that's provided in the request, by validating the OrgID in the claims. This is required because we don't restrict which project IDs can be requested from Tenant. Quarterdeck also does a check now but this ensures that these forbidden requests won't be forwarded to Quarterdeck.

Fixes SC-13098

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [x] security

### Acceptance criteria

Please review to make sure the logic makes sense and the new test cases are sufficient.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?