### PR TITLE
Decode quarterdeck errors

### DIFF
--- a/pkg/quarterdeck/api/v1/errors.go
+++ b/pkg/quarterdeck/api/v1/errors.go
@@ -109,3 +109,17 @@ type StatusError struct {
 func (e *StatusError) Error() string {
 	return fmt.Sprintf("[%d] %s", e.StatusCode, e.Reply.Error)
 }
+
+// ErrorStatus returns the HTTP status code from an error or 500 if the error is not a
+// StatusError.
+func ErrorStatus(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+
+	if e, ok := err.(*StatusError); !ok || e.StatusCode < 100 || e.StatusCode >= 600 {
+		return http.StatusInternalServerError
+	} else {
+		return e.StatusCode
+	}
+}

--- a/pkg/quarterdeck/api/v1/errors_test.go
+++ b/pkg/quarterdeck/api/v1/errors_test.go
@@ -77,3 +77,23 @@ func TestNotAllowed(t *testing.T) {
 	err := json.NewDecoder(result.Body).Decode(&data)
 	require.NoError(t, err)
 }
+
+func TestErrorStatus(t *testing.T) {
+	testCases := []struct {
+		err      error
+		expected int
+	}{
+		{nil, http.StatusOK},
+		{errors.New("not a StatusError"), http.StatusInternalServerError},
+		{&api.StatusError{}, http.StatusInternalServerError},
+		{&api.StatusError{StatusCode: http.StatusNotFound}, http.StatusNotFound},
+		{&api.StatusError{StatusCode: 99}, http.StatusInternalServerError},
+		{&api.StatusError{StatusCode: http.StatusContinue}, http.StatusContinue},
+		{&api.StatusError{StatusCode: http.StatusNotImplemented}, http.StatusNotImplemented},
+		{&api.StatusError{StatusCode: 600}, http.StatusInternalServerError},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expected, api.ErrorStatus(tc.err), "unexpected status code")
+	}
+}

--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -81,11 +81,10 @@ func (s *Server) ProjectAPIKeyList(c *gin.Context) {
 	}
 
 	// Request a page of API keys from Quarterdeck
-	// TODO: Handle error status codes returned by Quarterdeck
 	var reply *qd.APIKeyList
 	if reply, err = s.quarterdeck.APIKeyList(ctx, req); err != nil {
 		log.Error().Err(err).Msg("could not list API keys")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not list API keys"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not list API keys"))
 		return
 	}
 
@@ -185,11 +184,10 @@ func (s *Server) ProjectAPIKeyCreate(c *gin.Context) {
 	// TODO: Add source to request
 
 	// Create the API key with Quarterdeck
-	// TODO: Handle error status codes returned by Quarterdeck
 	var key *qd.APIKey
 	if key, err = s.quarterdeck.APIKeyCreate(ctx, req); err != nil {
 		log.Error().Err(err).Msg("could not create API key")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not create API key"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not create API key"))
 		return
 	}
 
@@ -238,11 +236,10 @@ func (s *Server) APIKeyDetail(c *gin.Context) {
 	apiKeyID := c.Param("apiKeyID")
 
 	// Get the API key from Quarterdeck
-	// TODO: Handle error status codes returned by Quarterdeck
 	var key *qd.APIKey
 	if key, err = s.quarterdeck.APIKeyDetail(ctx, apiKeyID); err != nil {
 		log.Error().Err(err).Str("apiKeyID", apiKeyID).Msg("could not get API key")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not retrieve API key"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not retrieve API key"))
 		return
 	}
 
@@ -323,11 +320,10 @@ func (s *Server) APIKeyUpdate(c *gin.Context) {
 	}
 
 	// Update the API key with Quarterdeck
-	// TODO: Handle error status codes returned by Quarterdeck
 	var key *qd.APIKey
 	if key, err = s.quarterdeck.APIKeyUpdate(ctx, req); err != nil {
 		log.Error().Err(err).Str("apiKeyID", apiKeyID).Msg("could not update API key")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not update API key"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not update API key"))
 		return
 	}
 
@@ -364,10 +360,9 @@ func (s *Server) APIKeyDelete(c *gin.Context) {
 	apiKeyID := c.Param("apiKeyID")
 
 	// Delete the API key using Quarterdeck
-	// TODO: Handle error status codes returned by Quarterdeck
 	if err = s.quarterdeck.APIKeyDelete(ctx, apiKeyID); err != nil {
 		log.Error().Err(err).Str("apiKeyID", apiKeyID).Msg("could not delete API key")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not delete API key"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not delete API key"))
 		return
 	}
 

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -54,11 +54,10 @@ func (s *Server) Register(c *gin.Context) {
 		PwCheck:  params.PwCheck,
 	}
 
-	// TODO: Handle error status codes returned by Quarterdeck
 	var reply *qd.RegisterReply
 	if reply, err = s.quarterdeck.Register(ctx, req); err != nil {
 		log.Error().Err(err).Msg("could not register user")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not complete registration"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not complete registration"))
 		return
 	}
 
@@ -130,11 +129,10 @@ func (s *Server) Login(c *gin.Context) {
 		Password: params.Password,
 	}
 
-	// TODO: Handle error status codes returned by Quarterdeck
 	var reply *qd.LoginReply
 	if reply, err = s.quarterdeck.Login(c.Request.Context(), req); err != nil {
 		log.Error().Err(err).Msg("could not login user")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not complete login"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not complete login"))
 		return
 	}
 


### PR DESCRIPTION
### Scope of changes

This should be a fairly straightforward PR - it adds a helper to decode Quarterdeck client errors into the HTTP status code. This is useful for Tenant because there are a few endpoints which make passthrough requests to Quarterdeck where we want to return the actual status code instead of 500.

Fixes SC-13115

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?