### PR TITLE
Tenant refresh endpoint

### DIFF
--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -328,7 +327,9 @@ func (s *APIv1) Do(req *http.Request, data interface{}, checkStatus bool) (rep *
 			if err = json.NewDecoder(rep.Body).Decode(&serr.Reply); err == nil {
 				return rep, serr
 			}
-			return rep, errors.New(rep.Status)
+
+			serr.Reply = unsuccessful
+			return rep, serr
 		}
 	}
 

--- a/pkg/quarterdeck/mock/quarterdeck.go
+++ b/pkg/quarterdeck/mock/quarterdeck.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/authtest"
 )
 
@@ -87,6 +88,7 @@ type HandlerOption func(*handlerOptions)
 type handlerOptions struct {
 	handler http.HandlerFunc
 	status  int
+	err     string
 	fixture interface{}
 	auth    bool
 }
@@ -119,6 +121,13 @@ func handler(opts ...HandlerOption) http.HandlerFunc {
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(conf.status)
 			json.NewEncoder(w).Encode(conf.fixture)
+		case conf.err != "":
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(conf.status)
+			reply := api.Reply{
+				Error: conf.err,
+			}
+			json.NewEncoder(w).Encode(reply)
 		default:
 			w.WriteHeader(conf.status)
 		}
@@ -129,6 +138,13 @@ func handler(opts ...HandlerOption) http.HandlerFunc {
 func UseStatus(status int) HandlerOption {
 	return func(o *handlerOptions) {
 		o.status = status
+	}
+}
+
+// Configure a basic error reply to be returned by the handler
+func UseError(err string) HandlerOption {
+	return func(o *handlerOptions) {
+		o.err = err
 	}
 }
 

--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -14,6 +14,7 @@ type TenantClient interface {
 
 	Register(context.Context, *RegisterRequest) error
 	Login(context.Context, *LoginRequest) (*AuthReply, error)
+	Refresh(context.Context, *RefreshRequest) (*AuthReply, error)
 
 	TenantList(context.Context, *PageQuery) (*TenantPage, error)
 	TenantCreate(context.Context, *Tenant) (*Tenant, error)
@@ -88,6 +89,10 @@ type RegisterRequest struct {
 type LoginRequest struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
+}
+
+type RefreshRequest struct {
+	RefreshToken string `json:"refresh_token"`
 }
 
 type AuthReply struct {

--- a/pkg/tenant/api/v1/client.go
+++ b/pkg/tenant/api/v1/client.go
@@ -126,6 +126,19 @@ func (s *APIv1) Login(ctx context.Context, in *LoginRequest) (out *AuthReply, er
 	return out, nil
 }
 
+func (s *APIv1) Refresh(ctx context.Context, in *RefreshRequest) (out *AuthReply, err error) {
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/refresh", in, nil); err != nil {
+		return nil, err
+	}
+
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *APIv1) TenantList(ctx context.Context, in *PageQuery) (out *TenantPage, err error) {
 	var params url.Values
 	if params, err = query.Values(in); err != nil {

--- a/pkg/tenant/api/v1/client_test.go
+++ b/pkg/tenant/api/v1/client_test.go
@@ -187,6 +187,36 @@ func TestLogin(t *testing.T) {
 	require.Equal(t, fixture, out, "expected the fixture to be returned")
 }
 
+func TestRefresh(t *testing.T) {
+	fixture := &api.AuthReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
+
+	// Create a test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/refresh", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a client to execute tests against the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create client")
+
+	// Create a new refresh request
+	req := &api.RefreshRequest{
+		RefreshToken: "refresh",
+	}
+	out, err := client.Refresh(context.Background(), req)
+	require.NoError(t, err, "could not execute refresh request")
+	require.Equal(t, fixture, out, "expected the fixture to be returned")
+}
+
 func TestTenantList(t *testing.T) {
 	fixture := &api.TenantPage{
 		Tenants: []*api.Tenant{

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -184,7 +184,7 @@ func (s *Server) Refresh(c *gin.Context) {
 	var reply *qd.LoginReply
 	if reply, err = s.quarterdeck.Refresh(c.Request.Context(), req); err != nil {
 		log.Error().Err(err).Msg("could not refresh user access token")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not complete refresh"))
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not complete refresh"))
 		return
 	}
 

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -157,6 +157,47 @@ func (s *Server) Login(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
+// Refresh is a publically accessible endpoint that allows users to refresh their
+// access token using their refresh token. This enables frontend clients to provide a
+// seamless login experience for the user.
+//
+// Route: POST /v1/refresh
+func (s *Server) Refresh(c *gin.Context) {
+	var err error
+
+	// Parse the request body
+	params := &api.RefreshRequest{}
+	if err = c.BindJSON(params); err != nil {
+		log.Warn().Err(err).Msg("could not parse request body")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("could not parse refresh request"))
+		return
+	}
+
+	// Validate that required fields were provided
+	if params.RefreshToken == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("missing refresh token"))
+		return
+	}
+
+	// Make the refresh request to Quarterdeck
+	req := &qd.RefreshRequest{
+		RefreshToken: params.RefreshToken,
+	}
+	var reply *qd.LoginReply
+	if reply, err = s.quarterdeck.Refresh(c.Request.Context(), req); err != nil {
+		log.Error().Err(err).Msg("could not refresh user access token")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not complete refresh"))
+		return
+	}
+
+	// Return the access and refresh tokens from Quarterdeck
+	out := &api.AuthReply{
+		AccessToken:  reply.AccessToken,
+		RefreshToken: reply.RefreshToken,
+	}
+	c.JSON(http.StatusOK, out)
+}
+
 // ProtectLogin prepares the front-end for login by setting the double cookie
 // tokens for CSRF protection.
 func (s *Server) ProtectLogin(c *gin.Context) {

--- a/pkg/tenant/auth_test.go
+++ b/pkg/tenant/auth_test.go
@@ -157,7 +157,7 @@ func (s *tenantTestSuite) TestRefresh() {
 	require.Equal(expected, rep, "unexpected refresh reply")
 
 	// Refresh method should handle errors from Quarterdeck
-	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusInternalServerError))
+	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusUnauthorized), mock.UseError("could not validate refresh token"))
 	_, err = s.client.Refresh(ctx, req)
-	s.requireError(err, http.StatusInternalServerError, "could not complete refresh")
+	s.requireError(err, http.StatusUnauthorized, "could not complete refresh")
 }

--- a/pkg/tenant/auth_test.go
+++ b/pkg/tenant/auth_test.go
@@ -126,3 +126,38 @@ func (s *tenantTestSuite) TestLogin() {
 	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusInternalServerError, "could not complete login")
 }
+
+func (s *tenantTestSuite) TestRefresh() {
+	require := s.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Create initial fixtures
+	reply := &qd.LoginReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
+
+	// Configure the initial mock to return a 200 response with the reply
+	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply))
+
+	// Refresh token is required
+	req := &api.RefreshRequest{}
+	_, err := s.client.Refresh(ctx, req)
+	s.requireError(err, http.StatusBadRequest, "missing refresh token")
+
+	// Successful refresh
+	expected := &api.AuthReply{
+		AccessToken:  reply.AccessToken,
+		RefreshToken: reply.RefreshToken,
+	}
+	req.RefreshToken = "refresh"
+	rep, err := s.client.Refresh(ctx, req)
+	require.NoError(err, "could not complete refresh")
+	require.Equal(expected, rep, "unexpected refresh reply")
+
+	// Refresh method should handle errors from Quarterdeck
+	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusInternalServerError))
+	_, err = s.client.Refresh(ctx, req)
+	s.requireError(err, http.StatusInternalServerError, "could not complete refresh")
+}

--- a/pkg/tenant/auth_test.go
+++ b/pkg/tenant/auth_test.go
@@ -157,7 +157,7 @@ func (s *tenantTestSuite) TestRefresh() {
 	require.Equal(expected, rep, "unexpected refresh reply")
 
 	// Refresh method should handle errors from Quarterdeck
-	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusUnauthorized), mock.UseError("could not validate refresh token"))
+	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusUnauthorized))
 	_, err = s.client.Refresh(ctx, req)
 	s.requireError(err, http.StatusUnauthorized, "could not complete refresh")
 }

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -269,9 +269,10 @@ func (s *Server) setupRoutes() (err error) {
 		// Set cookies for CSRF protection (authentication not required)
 		v1.GET("/login", s.ProtectLogin)
 
-		// Register and login routes (authentication not required)
+		// User auth routes (authentication not required)
 		v1.POST("/register", s.Register)
 		v1.POST("/login", s.Login)
+		v1.POST("/refresh", s.Refresh)
 
 		// Notification signups (authentication not required)
 		v1.POST("/notifications/signup", s.SignUp)


### PR DESCRIPTION
### Scope of changes

This adds a refresh passthrough endpoint to Tenant which calls Quarterdeck to refresh a user's access token.

Fixes SC-13149

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?