### PR TITLE
Docker compose profiles

### DIFF
--- a/containers/build.sh
+++ b/containers/build.sh
@@ -55,6 +55,7 @@ fi
 OPTIND=1
 TAG=${GIT_REVISION}
 PLATFORM="linux/amd64"
+PROFILE="all"
 
 while getopts htp: opt; do
     case $opt in
@@ -64,7 +65,9 @@ while getopts htp: opt; do
             ;;
         t)  TAG=$OPTARG
             ;;
-        p)  PLATFORM=$OPTARG
+        P)  PLATFORM=$OPTARG
+            ;;
+        p)  PROFILE=$OPTARG
             ;;
         *)
             show_help >&2
@@ -85,10 +88,10 @@ if [[ $# -eq 1 ]]; then
         docker system prune --all
         exit 0
     elif [[ $1 == "build" ]]; then
-        docker compose -p ensign -f $DIR/docker-compose.yaml build
+        docker compose -p ensign -f $DIR/docker-compose.yaml --profile=$PROFILE build
         exit 0
     elif [[ $1 == "up" ]]; then
-        docker compose -p ensign -f $DIR/docker-compose.yaml up
+        docker compose -p ensign -f $DIR/docker-compose.yaml --profile=$PROFILE up
         exit 0
     elif [[ $1 == "deploy" ]]; then
         echo "deploying ensign images"

--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -26,6 +26,10 @@ services:
       - ENSIGN_SENTRY_ENVIRONMENT=development
       - ENSIGN_SENTRY_TRACK_PERFORMANCE=false
 
+    profiles:
+      - backend
+      - all
+
   tenant:
     build:
       context: ../
@@ -62,6 +66,10 @@ services:
       - TENANT_SENTRY_ENVIRONMENT=development
       - TENANT_SENTRY_TRACK_PERFORMANCE=false
 
+    profiles:
+      - backend
+      - all
+
   quarterdeck:
     build:
       context: ../
@@ -92,6 +100,10 @@ services:
       - QUARTERDECK_SENTRY_ENVIRONMENT=development
       - QUARTERDECK_SENTRY_TRACK_PERFORMANCE=false
 
+    profiles:
+      - backend
+      - all
+
   beacon:
     build:
       context: ../
@@ -112,6 +124,10 @@ services:
       - tenant
     ports:
       - 3000:80
+
+    profiles:
+      - ui
+      - all
 
   trtl:
     image: trisa/trtl:latest
@@ -134,12 +150,20 @@ services:
       - TRTL_INSECURE=true
       - TRTL_BACKUP_ENABLED=false
 
+    profiles:
+      - backend
+      - all
+
   prometheus:
     image: prom/prometheus:latest
     ports:
       - 9090:9090
     volumes:
       - ./monitor/prometheus.yml:/etc/prometheus/prometheus.yml
+
+    profiles:
+      - monitoring
+      - all
 
   grafana:
     image: grafana/grafana:latest
@@ -149,3 +173,7 @@ services:
       - 9080:3000
     volumes:
       - ./monitor/grafana:/var/lib/grafana
+
+    profiles:
+      - monitoring
+      - all


### PR DESCRIPTION
### Scope of changes

This adds profile support to the docker compose, mostly to allow the frontend to build the backend and frontend separately to make development easier.

Currently supported profiles:

`backend`
`ui`
`monitoring`
`all`

Fixes SC-13536

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [x] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

The `build.sh` command should now support docker compose profiles with the `-p` option.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?
- [ ] Any profiles we want to change/add while we're here?