### PR TITLE
Fix tenant missing register fields

### DIFF
--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -44,11 +44,15 @@ func (s *Server) Register(c *gin.Context) {
 	// Make the register request to Quarterdeck
 	projectID := ulid.New()
 	req := &qd.RegisterRequest{
-		ProjectID: projectID.String(),
-		Name:      params.Name,
-		Email:     params.Email,
-		Password:  params.Password,
-		PwCheck:   params.PwCheck,
+		ProjectID:    projectID.String(),
+		Name:         params.Name,
+		Email:        params.Email,
+		Password:     params.Password,
+		PwCheck:      params.PwCheck,
+		Organization: params.Organization,
+		Domain:       params.Domain,
+		AgreeToS:     params.AgreeToS,
+		AgreePrivacy: params.AgreePrivacy,
 	}
 
 	var reply *qd.RegisterReply


### PR DESCRIPTION
### Scope of changes

This fixes an integration bug where Tenant was not populating all the fields for Quarterdeck on Register and modifies the tenant register test to ensure that we catch future changes.

Fixes SC-13632

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?