### PR TITLE
Tenant API object timestamps

### DIFF
--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -164,6 +164,8 @@ type Tenant struct {
 	ID              string `json:"id" uri:"id"`
 	Name            string `json:"name"`
 	EnvironmentType string `json:"environment_type"`
+	Created         string `json:"created,omitempty"`
+	Modified        string `json:"modified,omitempty"`
 }
 
 type TenantPage struct {
@@ -180,9 +182,11 @@ type TenantMemberPage struct {
 }
 
 type Member struct {
-	ID   string `json:"id" uri:"id"`
-	Name string `json:"name"`
-	Role string `json:"role"`
+	ID       string `json:"id" uri:"id"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+	Created  string `json:"created,omitempty"`
+	Modified string `json:"modified,omitempty"`
 }
 
 type MemberPage struct {
@@ -199,8 +203,10 @@ type TenantProjectPage struct {
 }
 
 type Project struct {
-	ID   string `json:"id" uri:"id"`
-	Name string `json:"name"`
+	ID       string `json:"id" uri:"id"`
+	Name     string `json:"name"`
+	Created  string `json:"created,omitempty"`
+	Modified string `json:"modified,omitempty"`
 }
 
 type ProjectPage struct {
@@ -217,8 +223,10 @@ type ProjectTopicPage struct {
 }
 
 type Topic struct {
-	ID   string `json:"id" uri:"id"`
-	Name string `json:"topic_name"`
+	ID       string `json:"id" uri:"id"`
+	Name     string `json:"topic_name"`
+	Created  string `json:"created,omitempty"`
+	Modified string `json:"modified,omitempty"`
 }
 
 type TopicPage struct {

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -158,7 +158,7 @@ func (s *Server) Login(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
-// Refresh is a publically accessible endpoint that allows users to refresh their
+// Refresh is a publicly accessible endpoint that allows users to refresh their
 // access token using their refresh token. This enables frontend clients to provide a
 // seamless login experience for the user.
 //

--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -174,6 +174,9 @@ func UpdateMember(ctx context.Context, member *Member) (err error) {
 	}
 
 	member.Modified = time.Now()
+	if member.Created.IsZero() {
+		member.Created = member.Modified
+	}
 
 	if err = Put(ctx, member); err != nil {
 		return err

--- a/pkg/tenant/db/members_test.go
+++ b/pkg/tenant/db/members_test.go
@@ -277,6 +277,11 @@ func (s *dbTestSuite) TestUpdateMember() {
 	require.Equal(time.Unix(1670424445, 0), member.Created, "expected created timestamp to not change")
 	require.True(time.Unix(1670424467, 0).Before(member.Modified), "expected modified timestamp to be updated")
 
+	// If created timestamp is missing then it should be updated
+	member.Created = time.Time{}
+	require.NoError(db.UpdateMember(ctx, member), "could not update member")
+	require.Equal(member.Modified, member.Created, "expected created timestamp to be updated")
+
 	// Test NotFound path
 	err = db.UpdateMember(ctx, &db.Member{OrgID: ulids.New(), TenantID: ulids.New(), ID: ulids.New(), Name: "member002", Role: "Admin"})
 	require.ErrorIs(err, db.ErrNotFound)

--- a/pkg/tenant/db/projects.go
+++ b/pkg/tenant/db/projects.go
@@ -160,6 +160,9 @@ func UpdateProject(ctx context.Context, project *Project) (err error) {
 	}
 
 	project.Modified = time.Now()
+	if project.Created.IsZero() {
+		project.Created = project.Modified
+	}
 
 	if err = Put(ctx, project); err != nil {
 		return err

--- a/pkg/tenant/db/projects_test.go
+++ b/pkg/tenant/db/projects_test.go
@@ -257,6 +257,11 @@ func (s *dbTestSuite) TestUpdateProject() {
 	require.Equal(time.Unix(1668660681, 0), project.Created, "expected created timestamp to not have changed")
 	require.True(time.Unix(1668660681, 0).Before(project.Modified), "expected modified timestamp to be updated")
 
+	// If created timestamp is missing then it should be updated
+	project.Created = time.Time{}
+	require.NoError(db.UpdateProject(ctx, project), "could not update project")
+	require.Equal(project.Modified, project.Created, "expected created timestamp to be updated")
+
 	// Test NotFound path
 	err = db.UpdateProject(ctx, &db.Project{OrgID: ulids.New(), TenantID: ulids.New(), ID: ulids.New(), Name: "project002"})
 	require.ErrorIs(err, db.ErrNotFound)

--- a/pkg/tenant/db/tenants.go
+++ b/pkg/tenant/db/tenants.go
@@ -145,6 +145,9 @@ func UpdateTenant(ctx context.Context, tenant *Tenant) (err error) {
 	}
 
 	tenant.Modified = time.Now()
+	if tenant.Created.IsZero() {
+		tenant.Created = tenant.Modified
+	}
 
 	if err = Put(ctx, tenant); err != nil {
 		return err

--- a/pkg/tenant/db/tenants_test.go
+++ b/pkg/tenant/db/tenants_test.go
@@ -255,6 +255,11 @@ func (s *dbTestSuite) TestUpdateTenant() {
 	require.Equal(time.Unix(1668574281, 0), tenant.Created, "expected created timestamp to not have changed")
 	require.True(time.Unix(1668574281, 0).Before(tenant.Modified), "expected modified timestamp to be updated")
 
+	// If created timestamp is missing then it should be updated
+	tenant.Created = time.Time{}
+	require.NoError(db.UpdateTenant(ctx, tenant), "could not update tenant")
+	require.Equal(tenant.Modified, tenant.Created, "expected created timestamp to be updated")
+
 	// Test NotFound path
 	err = db.UpdateTenant(ctx, &db.Tenant{OrgID: ulids.New(), ID: ulids.New(), Name: "tenant002", EnvironmentType: "dev"})
 	require.ErrorIs(err, db.ErrNotFound)

--- a/pkg/tenant/db/topics.go
+++ b/pkg/tenant/db/topics.go
@@ -145,6 +145,9 @@ func UpdateTopic(ctx context.Context, topic *Topic) (err error) {
 	}
 
 	topic.Modified = time.Now()
+	if topic.Created.IsZero() {
+		topic.Created = topic.Modified
+	}
 
 	if err = Put(ctx, topic); err != nil {
 		return err

--- a/pkg/tenant/db/topics_test.go
+++ b/pkg/tenant/db/topics_test.go
@@ -237,6 +237,11 @@ func (s *dbTestSuite) TestUpdateTopic() {
 	require.Equal(time.Unix(1672161102, 0), topic.Created, "expected created timestamp to have not changed")
 	require.True(time.Unix(1672161102, 0).Before(topic.Modified), "expected modified timestamp to be updated")
 
+	// If created timestamp is missing then it should be populated.
+	topic.Created = time.Time{}
+	require.NoError(db.UpdateTopic(ctx, topic), "could not update topic")
+	require.Equal(topic.Modified, topic.Created, "expected created timestamp to be populated")
+
 	// Test NotFound path.
 	err = db.UpdateTopic(ctx, &db.Topic{OrgID: ulids.New(), ProjectID: ulids.New(), ID: ulids.New(), Name: "topic002"})
 	require.ErrorIs(err, db.ErrNotFound)

--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
@@ -50,9 +51,11 @@ func (s *Server) TenantMemberList(c *gin.Context) {
 	// to that struct and then append to the out.TenantMembers array.
 	for _, dbMember := range members {
 		tenantMember := &api.Member{
-			ID:   dbMember.ID.String(),
-			Name: dbMember.Name,
-			Role: dbMember.Role,
+			ID:       dbMember.ID.String(),
+			Name:     dbMember.Name,
+			Role:     dbMember.Role,
+			Created:  dbMember.Created.Format(time.RFC3339Nano),
+			Modified: dbMember.Modified.Format(time.RFC3339Nano),
 		}
 		out.TenantMembers = append(out.TenantMembers, tenantMember)
 	}
@@ -152,9 +155,11 @@ func (s *Server) TenantMemberCreate(c *gin.Context) {
 	}
 
 	out = &api.Member{
-		ID:   tmember.ID.String(),
-		Name: member.Name,
-		Role: member.Role,
+		ID:       tmember.ID.String(),
+		Name:     member.Name,
+		Role:     member.Role,
+		Created:  tmember.Created.Format(time.RFC3339Nano),
+		Modified: tmember.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusCreated, out)
@@ -199,9 +204,11 @@ func (s *Server) MemberList(c *gin.Context) {
 	// Loop over db.Member and retrieve each member.
 	for _, dbMember := range members {
 		member := &api.Member{
-			ID:   dbMember.ID.String(),
-			Name: dbMember.Name,
-			Role: dbMember.Role,
+			ID:       dbMember.ID.String(),
+			Name:     dbMember.Name,
+			Role:     dbMember.Role,
+			Created:  dbMember.Created.Format(time.RFC3339Nano),
+			Modified: dbMember.Modified.Format(time.RFC3339Nano),
 		}
 		out.Members = append(out.Members, member)
 	}
@@ -274,9 +281,11 @@ func (s *Server) MemberCreate(c *gin.Context) {
 	}
 
 	out := &api.Member{
-		ID:   dbMember.ID.String(),
-		Name: member.Name,
-		Role: member.Role,
+		ID:       dbMember.ID.String(),
+		Name:     member.Name,
+		Role:     member.Role,
+		Created:  dbMember.Created.Format(time.RFC3339Nano),
+		Modified: dbMember.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusCreated, out)
@@ -310,9 +319,11 @@ func (s *Server) MemberDetail(c *gin.Context) {
 	}
 
 	reply = &api.Member{
-		ID:   member.ID.String(),
-		Name: member.Name,
-		Role: member.Role,
+		ID:       member.ID.String(),
+		Name:     member.Name,
+		Role:     member.Role,
+		Created:  member.Created.Format(time.RFC3339Nano),
+		Modified: member.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusOK, reply)
@@ -372,6 +383,14 @@ func (s *Server) MemberUpdate(c *gin.Context) {
 		log.Error().Err(err).Str("memberID", memberID.String()).Msg("could not save member")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not update member"))
 		return
+	}
+
+	member = &api.Member{
+		ID:       m.ID.String(),
+		Name:     m.Name,
+		Role:     m.Role,
+		Created:  m.Created.Format(time.RFC3339Nano),
+		Modified: m.Modified.Format(time.RFC3339Nano),
 	}
 	c.JSON(http.StatusOK, member)
 }

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -114,6 +114,8 @@ func (suite *tenantTestSuite) TestTenantMemberList() {
 		require.Equal(members[i].ID.String(), rep.TenantMembers[i].ID, "expected member id to match")
 		require.Equal(members[i].Name, rep.TenantMembers[i].Name, "expected member name to match")
 		require.Equal(members[i].Role, rep.TenantMembers[i].Role, "expected member role to match")
+		require.Equal(members[i].Created.Format(time.RFC3339Nano), rep.TenantMembers[i].Created, "expected member created to match")
+		require.Equal(members[i].Modified.Format(time.RFC3339Nano), rep.TenantMembers[i].Modified, "expected member modified to match")
 	}
 }
 
@@ -221,6 +223,8 @@ func (suite *tenantTestSuite) TestTenantMemberCreate() {
 	require.NotEmpty(member.ID, "expected non-zero ulid to be populated")
 	require.Equal(req.Name, member.Name, "member name should match")
 	require.Equal(req.Role, member.Role, "member role should match")
+	require.NotEmpty(member.Created, "expected non-zero time to be populated")
+	require.NotEmpty(member.Modified, "expected non-zero time to be populated")
 }
 
 func (suite *tenantTestSuite) TestMemberList() {
@@ -314,6 +318,8 @@ func (suite *tenantTestSuite) TestMemberList() {
 		require.Equal(members[i].ID.String(), rep.Members[i].ID, "expected member id to match")
 		require.Equal(members[i].Name, rep.Members[i].Name, "expected member name to match")
 		require.Equal(members[i].Role, rep.Members[i].Role, "expected member role to match")
+		require.Equal(members[i].Created.Format(time.RFC3339Nano), rep.Members[i].Created, "expected member created time to match")
+		require.Equal(members[i].Modified.Format(time.RFC3339Nano), rep.Members[i].Modified, "expected member modified time to match")
 	}
 
 	// Set test fixture.
@@ -389,6 +395,8 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 	require.NotEmpty(rep.ID, "expected non-zero ulid to be populated")
 	require.Equal(req.Name, rep.Name, "expected memeber name to match")
 	require.Equal(req.Role, rep.Role, "expected member role to match")
+	require.NotEmpty(rep.Created, "expected created time to be populated")
+	require.NotEmpty(rep.Modified, "expected modified time to be populated")
 
 	// Create a test fixture.
 	test := &tokens.Claims{
@@ -470,6 +478,8 @@ func (suite *tenantTestSuite) TestMemberDetail() {
 	require.Equal(req.ID, rep.ID, "expected member id to match")
 	require.Equal(req.Name, rep.Name, "expected member name to match")
 	require.Equal(req.Role, rep.Role, "expected member role to match")
+	require.NotEmpty(rep.Created, "expected created time to be populated")
+	require.NotEmpty(rep.Modified, "expected modified time to be populated")
 }
 
 func (suite *tenantTestSuite) TestMemberUpdate() {
@@ -492,11 +502,6 @@ func (suite *tenantTestSuite) TestMemberUpdate() {
 	// Marshal the data with msgpack
 	data, err := member.MarshalValue()
 	require.NoError(err, "could not marshal the member")
-
-	// Unmarshal the data with msgpack
-	other := &db.Member{}
-	err = other.UnmarshalValue(data)
-	require.NoError(err, "could not unmarshal the member")
 
 	// OnGet method should return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
@@ -555,6 +560,8 @@ func (suite *tenantTestSuite) TestMemberUpdate() {
 	require.NotEqual(req.ID, "01GM8MEZ097ZC7RQRCWMPRPS0T", "member id should not match")
 	require.Equal(rep.Name, req.Name, "expected member name to match")
 	require.Equal(rep.Role, req.Role, "expected member role to match")
+	require.NotEmpty(rep.Created, "expected created time to be populated")
+	require.NotEmpty(rep.Modified, "expected modified time to be populated")
 }
 
 func (suite *tenantTestSuite) TestMemberDelete() {

--- a/pkg/tenant/projects.go
+++ b/pkg/tenant/projects.go
@@ -3,6 +3,7 @@ package tenant
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
@@ -51,8 +52,10 @@ func (s *Server) TenantProjectList(c *gin.Context) {
 	// to that struct and then append to the out.TenantProjects array.
 	for _, dbProject := range projects {
 		tenantProject := &api.Project{
-			ID:   dbProject.ID.String(),
-			Name: dbProject.Name,
+			ID:       dbProject.ID.String(),
+			Name:     dbProject.Name,
+			Created:  dbProject.Created.Format(time.RFC3339Nano),
+			Modified: dbProject.Modified.Format(time.RFC3339Nano),
 		}
 		out.TenantProjects = append(out.TenantProjects, tenantProject)
 	}
@@ -141,8 +144,10 @@ func (s *Server) TenantProjectCreate(c *gin.Context) {
 	}
 
 	out = &api.Project{
-		ID:   tproject.ID.String(),
-		Name: tproject.Name,
+		ID:       tproject.ID.String(),
+		Name:     tproject.Name,
+		Created:  tproject.Created.Format(time.RFC3339Nano),
+		Modified: tproject.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusCreated, out)
@@ -187,8 +192,10 @@ func (s *Server) ProjectList(c *gin.Context) {
 	//Loop over db.Project and retrieve each project.
 	for _, dbProject := range projects {
 		project := &api.Project{
-			ID:   dbProject.ID.String(),
-			Name: dbProject.Name,
+			ID:       dbProject.ID.String(),
+			Name:     dbProject.Name,
+			Created:  dbProject.Created.Format(time.RFC3339Nano),
+			Modified: dbProject.Modified.Format(time.RFC3339Nano),
 		}
 		out.Projects = append(out.Projects, project)
 	}
@@ -264,8 +271,10 @@ func (s *Server) ProjectCreate(c *gin.Context) {
 	}
 
 	out := &api.Project{
-		ID:   dbProject.ID.String(),
-		Name: dbProject.Name,
+		ID:       dbProject.ID.String(),
+		Name:     dbProject.Name,
+		Created:  dbProject.Created.Format(time.RFC3339Nano),
+		Modified: dbProject.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusCreated, out)
@@ -300,8 +309,10 @@ func (s *Server) ProjectDetail(c *gin.Context) {
 	}
 
 	reply = &api.Project{
-		ID:   project.ID.String(),
-		Name: project.Name,
+		ID:       project.ID.String(),
+		Name:     project.Name,
+		Created:  project.Created.Format(time.RFC3339Nano),
+		Modified: project.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusOK, reply)
@@ -355,6 +366,13 @@ func (s *Server) ProjectUpdate(c *gin.Context) {
 		log.Error().Err(err).Str("projectID", projectID.String()).Msg("could not save project")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not update project"))
 		return
+	}
+
+	project = &api.Project{
+		ID:       p.ID.String(),
+		Name:     p.Name,
+		Created:  p.Created.Format(time.RFC3339Nano),
+		Modified: p.Modified.Format(time.RFC3339Nano),
 	}
 	c.JSON(http.StatusOK, project)
 }

--- a/pkg/tenant/projects_test.go
+++ b/pkg/tenant/projects_test.go
@@ -110,6 +110,8 @@ func (suite *tenantTestSuite) TestTenantProjectList() {
 	for i := range projects {
 		require.Equal(projects[i].ID.String(), rep.TenantProjects[i].ID, "expected project id to match")
 		require.Equal(projects[i].Name, rep.TenantProjects[i].Name, "expected project name to match")
+		require.Equal(projects[i].Created.Format(time.RFC3339Nano), rep.TenantProjects[i].Created, "expected project created time to match")
+		require.Equal(projects[i].Modified.Format(time.RFC3339Nano), rep.TenantProjects[i].Modified, "expected project modified time to match")
 	}
 }
 
@@ -174,6 +176,8 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 	require.NoError(err, "could not add project")
 	require.NotEmpty(project.ID, "expected non-zero ulid to be populated")
 	require.Equal(req.Name, project.Name, "project name should match")
+	require.NotEmpty(project.Created, "expected non-zero created time to be populated")
+	require.NotEmpty(project.Modified, "expected non-zero modified time to be populated")
 
 	// Should return an error if the Quarterdeck returns an error
 	suite.quarterdeck.OnProjects(mock.UseStatus(http.StatusInternalServerError), mock.RequireAuth())
@@ -272,6 +276,8 @@ func (suite *tenantTestSuite) TestProjectList() {
 	for i := range projects {
 		require.Equal(projects[i].ID.String(), rep.Projects[i].ID, "project id should match")
 		require.Equal(projects[i].Name, rep.Projects[i].Name, "project name should match")
+		require.Equal(projects[i].Created.Format(time.RFC3339Nano), rep.Projects[i].Created, "project created should match")
+		require.Equal(projects[i].Modified.Format(time.RFC3339Nano), rep.Projects[i].Modified, "project modified should match")
 	}
 
 	// Set test fixture.
@@ -343,6 +349,8 @@ func (suite *tenantTestSuite) TestProjectCreate() {
 	project, err := suite.client.ProjectCreate(ctx, req)
 	require.NoError(err, "could not add project")
 	require.Equal(req.Name, project.Name)
+	require.NotEmpty(project.Created, "project created should not be empty")
+	require.NotEmpty(project.Modified, "project modified should not be empty")
 
 	// Should return an error if the Quarterdeck returns an error
 	suite.quarterdeck.OnProjects(mock.UseStatus(http.StatusInternalServerError), mock.RequireAuth())
@@ -366,6 +374,8 @@ func (suite *tenantTestSuite) TestProjectDetail() {
 		TenantID: ulid.MustParse("01GMTWFK4XZY597Y128KXQ4WHP"),
 		ID:       ulid.MustParse("01GKKYAWC4PA72YC53RVXAEC67"),
 		Name:     "project001",
+		Created:  time.Now().Add(-time.Hour),
+		Modified: time.Now(),
 	}
 
 	// Marshal the project data with msgpack.
@@ -418,6 +428,8 @@ func (suite *tenantTestSuite) TestProjectDetail() {
 	require.NoError(err, "could not retrieve project")
 	require.Equal(req.ID, rep.ID, "expected project id to match")
 	require.Equal(req.Name, rep.Name, "expected project name to match")
+	require.Equal(project.Created.Format(time.RFC3339Nano), rep.Created, "expected project created to match")
+	require.Equal(project.Modified.Format(time.RFC3339Nano), rep.Modified, "expected project modified to match")
 
 	// Should return an error if the project ID is parsed but not found.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
@@ -503,6 +515,8 @@ func (suite *tenantTestSuite) TestProjectUpdate() {
 	require.NoError(err, "could not update project")
 	require.NotEqual(req.ID, "01GMTWFK4XZY597Y128KXQ4WHP", "project id should not match")
 	require.Equal(rep.Name, req.Name, "expected project name to match")
+	require.NotEmpty(rep.Created, "expected project created to be set")
+	require.NotEmpty(rep.Modified, "expected project modified to be set")
 
 	// Should return an error if the project ID is parsed but not found.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {

--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -3,6 +3,7 @@ package tenant
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
@@ -56,6 +57,8 @@ func (s *Server) TenantList(c *gin.Context) {
 			ID:              dbTenant.ID.String(),
 			Name:            dbTenant.Name,
 			EnvironmentType: dbTenant.EnvironmentType,
+			Created:         dbTenant.Created.Format(time.RFC3339Nano),
+			Modified:        dbTenant.Modified.Format(time.RFC3339Nano),
 		}
 		out.Tenants = append(out.Tenants, tenant)
 	}
@@ -134,6 +137,8 @@ func (s *Server) TenantCreate(c *gin.Context) {
 		ID:              tenant.ID.String(),
 		Name:            tenant.Name,
 		EnvironmentType: tenant.EnvironmentType,
+		Created:         tenant.Created.Format(time.RFC3339Nano),
+		Modified:        tenant.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusCreated, out)
@@ -171,6 +176,8 @@ func (s *Server) TenantDetail(c *gin.Context) {
 		ID:              tenant.ID.String(),
 		Name:            tenant.Name,
 		EnvironmentType: tenant.EnvironmentType,
+		Created:         tenant.Created.Format(time.RFC3339Nano),
+		Modified:        tenant.Modified.Format(time.RFC3339Nano),
 	}
 	c.JSON(http.StatusOK, reply)
 }
@@ -232,6 +239,13 @@ func (s *Server) TenantUpdate(c *gin.Context) {
 		return
 	}
 
+	tenant = &api.Tenant{
+		ID:              t.ID.String(),
+		Name:            t.Name,
+		EnvironmentType: t.EnvironmentType,
+		Created:         t.Created.Format(time.RFC3339Nano),
+		Modified:        t.Modified.Format(time.RFC3339Nano),
+	}
 	c.JSON(http.StatusOK, tenant)
 }
 

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -112,6 +112,9 @@ func (suite *tenantTestSuite) TestTenantList() {
 		require.Equal(tenants[i].ID.String(), rep.Tenants[i].ID, "tenant id should match")
 		require.Equal(tenants[i].Name, rep.Tenants[i].Name, "tenant name should match")
 		require.Equal(tenants[i].EnvironmentType, rep.Tenants[i].EnvironmentType, "tenant environment type should match")
+		require.Equal(tenants[i].Created.Format(time.RFC3339Nano), rep.Tenants[i].Created, "tenant created timestamp should match")
+		require.Equal(tenants[i].Modified.Format(time.RFC3339Nano), rep.Tenants[i].Modified, "tenant modified timestamp should match")
+
 	}
 
 	// Set test fixture.
@@ -187,6 +190,8 @@ func (suite *tenantTestSuite) TestTenantCreate() {
 	require.NotEmpty(rep.ID, "expected non-zero ulid to be populated")
 	require.Equal(req.Name, rep.Name, "tenant name should match")
 	require.Equal(req.EnvironmentType, rep.EnvironmentType, "tenant environment type should match")
+	require.NotEmpty(rep.Created, "expected non-zero created timestamp to be populated")
+	require.NotEmpty(rep.Modified, "expected non-zero modified timestamp to be populated")
 
 	// Create a test fixture.
 	test := &tokens.Claims{
@@ -269,6 +274,8 @@ func (suite *tenantTestSuite) TestTenantDetail() {
 	require.Equal(req.ID, reply.ID, "tenant id should match")
 	require.Equal(req.Name, reply.Name, "tenant name should match")
 	require.Equal(req.EnvironmentType, reply.EnvironmentType, "tenant environment type should match")
+	require.NotEmpty(reply.Created, "expected non-zero created timestamp to be populated")
+	require.NotEmpty(reply.Modified, "expected non-zero modified timestamp to be populated")
 }
 
 func (suite *tenantTestSuite) TestTenantUpdate() {
@@ -290,11 +297,6 @@ func (suite *tenantTestSuite) TestTenantUpdate() {
 	// Marshal the data with msgpack
 	data, err := fixture.MarshalValue()
 	require.NoError(err, "could not marshal the tenant")
-
-	// Unmarshal the data with msgpack
-	other := &db.Tenant{}
-	err = other.UnmarshalValue(data)
-	require.NoError(err, "could not unmarshal the tenant")
 
 	// OnGet should return the test data.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
@@ -350,8 +352,10 @@ func (suite *tenantTestSuite) TestTenantUpdate() {
 	rep, err := suite.client.TenantUpdate(ctx, req)
 	require.NoError(err, "could not update tenant")
 	require.NotEqual(req.ID, "01GM8MEZ097ZC7RQRCWMPRPS0T", "tenant id should not match")
-	require.Equal(req.Name, rep.Name, "tenant name should match")
-	require.Equal(req.EnvironmentType, rep.EnvironmentType, "tenant environment type should match")
+	require.Equal(fixture.Name, rep.Name, "tenant name should match")
+	require.Equal(fixture.EnvironmentType, rep.EnvironmentType, "tenant environment type should match")
+	require.NotEmpty(rep.Created, "expected non-zero created timestamp to be populated")
+	require.NotEmpty(rep.Modified, "expected non-zero modified timestamp to be populated")
 }
 
 func (suite *tenantTestSuite) TestTenantDelete() {

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
@@ -50,8 +51,10 @@ func (s *Server) ProjectTopicList(c *gin.Context) {
 	// to that struct and then append to the out.Topics array.
 	for _, dbTopic := range topics {
 		topic := &api.Topic{
-			ID:   dbTopic.ID.String(),
-			Name: dbTopic.Name,
+			ID:       dbTopic.ID.String(),
+			Name:     dbTopic.Name,
+			Created:  dbTopic.Created.Format(time.RFC3339Nano),
+			Modified: dbTopic.Modified.Format(time.RFC3339Nano),
 		}
 		out.Topics = append(out.Topics, topic)
 	}
@@ -130,8 +133,10 @@ func (s *Server) ProjectTopicCreate(c *gin.Context) {
 	}
 
 	out = &api.Topic{
-		ID:   t.ID.String(),
-		Name: topic.Name,
+		ID:       t.ID.String(),
+		Name:     topic.Name,
+		Created:  t.Created.Format(time.RFC3339Nano),
+		Modified: t.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusCreated, out)
@@ -181,8 +186,10 @@ func (s *Server) TopicList(c *gin.Context) {
 	// Loop over db.Topic and retrieve each topic.
 	for _, dbTopic := range topics {
 		topic := &api.Topic{
-			ID:   dbTopic.ID.String(),
-			Name: dbTopic.Name,
+			ID:       dbTopic.ID.String(),
+			Name:     dbTopic.Name,
+			Created:  dbTopic.Created.Format(time.RFC3339Nano),
+			Modified: dbTopic.Modified.Format(time.RFC3339Nano),
 		}
 		out.Topics = append(out.Topics, topic)
 	}
@@ -219,8 +226,10 @@ func (s *Server) TopicDetail(c *gin.Context) {
 	}
 
 	reply = &api.Topic{
-		ID:   topic.ID.String(),
-		Name: topic.Name,
+		ID:       topic.ID.String(),
+		Name:     topic.Name,
+		Created:  topic.Created.Format(time.RFC3339Nano),
+		Modified: topic.Modified.Format(time.RFC3339Nano),
 	}
 
 	c.JSON(http.StatusOK, reply)
@@ -276,6 +285,12 @@ func (s *Server) TopicUpdate(c *gin.Context) {
 		return
 	}
 
+	topic = &api.Topic{
+		ID:       t.ID.String(),
+		Name:     t.Name,
+		Created:  t.Created.Format(time.RFC3339Nano),
+		Modified: t.Modified.Format(time.RFC3339Nano),
+	}
 	c.JSON(http.StatusOK, topic)
 }
 

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -108,6 +108,8 @@ func (suite *tenantTestSuite) TestProjectTopicList() {
 	for i := range topics {
 		require.Equal(topics[i].ID.String(), rep.Topics[i].ID, "expected topic id to match")
 		require.Equal(topics[i].Name, rep.Topics[i].Name, "expected topic name to match")
+		require.Equal(topics[i].Created.Format(time.RFC3339Nano), rep.Topics[i].Created, "expected topic created to match")
+		require.Equal(topics[i].Modified.Format(time.RFC3339Nano), rep.Topics[i].Modified, "expected topic modified to match")
 	}
 }
 
@@ -168,6 +170,8 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 	require.NoError(err, "could not add topic")
 	require.NotEmpty(topic.ID, "expected non-zero ulid to be populated")
 	require.Equal(req.Name, topic.Name, "expected topic name to match")
+	require.NotEmpty(topic.Created, "expected created to be populated")
+	require.NotEmpty(topic.Modified, "expected modified to be populated")
 
 	// Create a test fixture.
 	test := &tokens.Claims{
@@ -269,6 +273,8 @@ func (suite *tenantTestSuite) TestTopicList() {
 	for i := range topics {
 		require.Equal(topics[i].ID.String(), rep.Topics[i].ID, "expected topic id to match")
 		require.Equal(topics[i].Name, rep.Topics[i].Name, "expected topic name to match")
+		require.Equal(topics[i].Created.Format(time.RFC3339Nano), rep.Topics[i].Created, "expected topic created to match")
+		require.Equal(topics[i].Modified.Format(time.RFC3339Nano), rep.Topics[i].Modified, "expected topic modified to match")
 	}
 
 	// Set test fixture.
@@ -351,6 +357,8 @@ func (suite *tenantTestSuite) TestTopicDetail() {
 	require.NoError(err, "could not retrieve topic")
 	require.Equal(req.ID, rep.ID, "expected topic ID to match")
 	require.Equal(req.Name, rep.Name, "expected topic name to match")
+	require.NotEmpty(rep.Created, "expected topic created to be set")
+	require.NotEmpty(rep.Modified, "expected topic modified to be set")
 
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
 		return nil, errors.New("key not found")
@@ -437,6 +445,8 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 	require.NoError(err, "could not update topic")
 	require.NotEqual(req.ID, "", "topic id should not match")
 	require.Equal(req.Name, rep.Name, "expected topic name to match")
+	require.NotEmpty(rep.Created, "expected topic created to be set")
+	require.NotEmpty(rep.Modified, "expected topic modified to be set")
 
 	// Should return an error if the topic ID is parsed but not found.
 	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {


### PR DESCRIPTION
### Scope of changes

This updates the tenant API objects to include the created and modified timestamps so that they are returned to the frontend.

Fixes SC-13690

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This should be pretty straightforward, just need a cursory look through to make sure we've covered all the API models.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?