### PR TITLE
Only refresh tokens should be allowed to reauthenticate

### DIFF
--- a/pkg/quarterdeck/auth_test.go
+++ b/pkg/quarterdeck/auth_test.go
@@ -265,4 +265,8 @@ func (s *quarterdeckTestSuite) TestRefresh() {
 	// Test invalid refresh token returns error
 	_, err = s.client.Refresh(ctx, &api.RefreshRequest{RefreshToken: "refresh"})
 	s.CheckError(err, http.StatusForbidden, "could not verify refresh token")
+
+	// Test validating with an access token returns an error
+	_, err = s.client.Refresh(ctx, &api.RefreshRequest{RefreshToken: newTokens.AccessToken})
+	s.CheckError(err, http.StatusForbidden, "could not verify refresh token")
 }

--- a/pkg/quarterdeck/config/config.go
+++ b/pkg/quarterdeck/config/config.go
@@ -37,7 +37,7 @@ type DatabaseConfig struct {
 type TokenConfig struct {
 	Keys            map[string]string `required:"false"`                      // $QUARTERDECK_TOKEN_KEYS
 	Audience        string            `default:"ensign.rotational.app:443"`   // $QUARTERDECK_TOKEN_AUDIENCE
-	RefreshAudience string            `required:"false"`                      // $QUARTERDEKC_TOKEN_REFRESH_AUDIENCE
+	RefreshAudience string            `required:"false"`                      // $QUARTERDECK_TOKEN_REFRESH_AUDIENCE
 	Issuer          string            `default:"https://auth.rotational.app"` // $QUARTERDECK_TOKEN_ISSUER
 	AccessDuration  time.Duration     `split_words:"true" default:"1h"`       // $QUARTERDECK_TOKEN_ACCESS_DURATION
 	RefreshDuration time.Duration     `split_words:"true" default:"2h"`       // $QUARTERDECK_TOKEN_REFRESH_DURATION

--- a/pkg/quarterdeck/config/config.go
+++ b/pkg/quarterdeck/config/config.go
@@ -37,6 +37,7 @@ type DatabaseConfig struct {
 type TokenConfig struct {
 	Keys            map[string]string `required:"false"`                      // $QUARTERDECK_TOKEN_KEYS
 	Audience        string            `default:"ensign.rotational.app:443"`   // $QUARTERDECK_TOKEN_AUDIENCE
+	RefreshAudience string            `required:"false"`                      // $QUARTERDEKC_TOKEN_REFRESH_AUDIENCE
 	Issuer          string            `default:"https://auth.rotational.app"` // $QUARTERDECK_TOKEN_ISSUER
 	AccessDuration  time.Duration     `split_words:"true" default:"1h"`       // $QUARTERDECK_TOKEN_ACCESS_DURATION
 	RefreshDuration time.Duration     `split_words:"true" default:"2h"`       // $QUARTERDECK_TOKEN_REFRESH_DURATION

--- a/pkg/quarterdeck/tokens/tokens_test.go
+++ b/pkg/quarterdeck/tokens/tokens_test.go
@@ -109,6 +109,7 @@ func (s *TokenTestSuite) TestTokenManager() {
 	rc := refreshToken.Claims.(*tokens.Claims)
 	require.Equal(ac.ID, rc.ID, "access and refresh tokens must have same jid")
 	require.Equal(jwt.ClaimStrings{"http://localhost:3000", "http://localhost:3001/v1/refresh"}, rc.Audience)
+	require.NotEqual(ac.Audience, rc.Audience, "identical access token and refresh token audience")
 	require.Equal(ac.Issuer, rc.Issuer)
 	require.Equal(ac.Subject, rc.Subject)
 	require.True(rc.IssuedAt.Equal(ac.IssuedAt.Time))

--- a/pkg/quarterdeck/tokens/tokens_test.go
+++ b/pkg/quarterdeck/tokens/tokens_test.go
@@ -108,7 +108,7 @@ func (s *TokenTestSuite) TestTokenManager() {
 	// Check access token claims
 	rc := refreshToken.Claims.(*tokens.Claims)
 	require.Equal(ac.ID, rc.ID, "access and refresh tokens must have same jid")
-	require.Equal(ac.Audience, rc.Audience)
+	require.Equal(jwt.ClaimStrings{"http://localhost:3000", "http://localhost:3001/v1/refresh"}, rc.Audience)
 	require.Equal(ac.Issuer, rc.Issuer)
 	require.Equal(ac.Subject, rc.Subject)
 	require.True(rc.IssuedAt.Equal(ac.IssuedAt.Time))


### PR DESCRIPTION
### Scope of changes

Adds another audience to refresh tokens that identifies them as refresh tokens and verifies them in the Refresh handler. 

The basic fix is as follows, the `aud` claim in a JWT token can have multiple items. Access tokens have the audience claim `[https://api.rotational.app]` but refresh tokens now have the audience claim `[https://api.rotational.app, https://auth.rotational.app/v1/refresh]`. This means that the refresh tokens go through two checks; one that the audience claim `https://api.rotational.app` is good and then that `https://auth.rotational.app/v1/refresh` is in the token. 

I've added a test that shows that valid access tokens are rejected since they don't have this audience. 

Fixes SC-13078

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

I'm worried about the security of this model. Should we add a check that requires the access token, possibly expired be in the Authorization header then match the IDs of the two claims before we refresh? 

I kind of feel like we should; particularly if we put the access token in a Cookie that is http only and secure. 

@masskoder @pdamodaran any thoughts on this? 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?
- [ ] Should we add another test ensuring that the new access/refresh token have the same claims, particularly the audience? Just to make sure that it doesn't accidentally change in the future?