### PR TITLE
Refactor Quarterdeck WaitForReady Backoff

### DIFF
--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -399,8 +399,7 @@ func (s *APIv1) WaitForReady(ctx context.Context) (err error) {
 	}
 
 	// Create exponential backoff ticker for retries
-	ticker := backoff.NewTicker(backoff.NewExponentialBackOff())
-	defer ticker.Stop()
+	ticker := backoff.NewExponentialBackOff()
 
 	// Keep checking if Quarterdeck is ready until it is ready or until the context expires.
 	for {
@@ -412,12 +411,13 @@ func (s *APIv1) WaitForReady(ctx context.Context) (err error) {
 
 		// Log the error warning that we're still waiting to connect to quarterdeck
 		log.Warn().Err(err).Msg("waiting to connect to quarterdeck")
+		wait := time.After(ticker.NextBackOff())
 
 		// Wait for the context to be done or for the ticker to move to the next backoff.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ticker.C:
+		case <-wait:
 		}
 	}
 }

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -539,6 +539,19 @@ func TestAccountUpdate(t *testing.T) {
 }
 
 func TestWaitForReady(t *testing.T) {
+	// Backoff Interval should be as follows:
+	// Request #   Retry Interval (sec)     Randomized Interval (sec)
+	//   1          0.5                     [0.25,   0.75]
+	//   2          0.75                    [0.375,  1.125]
+	//   3          1.125                   [0.562,  1.687]
+	//   4          1.687                   [0.8435, 2.53]
+	//   5          2.53                    [1.265,  3.795]
+	//   6          3.795                   [1.897,  5.692]
+	//   7          5.692                   [2.846,  8.538]
+	//   8          8.538                   [4.269, 12.807]
+	//   9         12.807                   [6.403, 19.210]
+	//  10         19.210                   backoff.Stop
+
 	fixture := &api.StatusReply{
 		Version: "1.0.test",
 	}
@@ -549,7 +562,7 @@ func TestWaitForReady(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tries++
 		var status int
-		if tries < 4 {
+		if tries < 3 {
 			status = http.StatusServiceUnavailable
 			fixture.Status = "maintenance"
 		} else {
@@ -569,9 +582,11 @@ func TestWaitForReady(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err)
 
+	// We expect it takes 5 tries before a good response is returned that means that
+	// the minimum delay according to the above table is 1.187 seconds
 	err = client.WaitForReady(context.Background())
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, time.Since(started), 1000*time.Millisecond)
+	require.GreaterOrEqual(t, time.Since(started), 1187*time.Millisecond)
 
 	// Should not have any wait since the test server will respond true
 	err = client.WaitForReady(context.Background())
@@ -579,7 +594,7 @@ func TestWaitForReady(t *testing.T) {
 
 	// Test timeout
 	tries = 0
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	err = client.WaitForReady(ctx)
 	require.ErrorIs(t, err, context.DeadlineExceeded)


### PR DESCRIPTION
### Scope of changes

Updates the Quarterdeck WaitForReady Backoff to include the time of making requests instead of using a ticker to hopefully fix the Go 1.20 tests in CI.

Fixes SC-13959

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

I guess mainly we just have to see if my reasoning in the PR is correct and if CI passes for Go 1.20. 

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?