### PR TITLE
Send verification email in async task

### DIFF
--- a/pkg/quarterdeck/auth.go
+++ b/pkg/quarterdeck/auth.go
@@ -104,11 +104,14 @@ func (s *Server) Register(c *gin.Context) {
 		return
 	}
 
-	// Now that the user exists in the database, send them a verification email
-	if err = s.SendVerificationEmail(user); err != nil {
-		log.Error().Err(err).Msg("could not send verification email")
-		// TODO: If we fail to send the email should we create a retry task?
-	}
+	// Verification emails should happen asynchronously because sending emails can be
+	// slow and waiting for SendGrid to send the email could cause the request to time
+	// out even though the user was successfully created.
+	s.tasks.Queue(tasks.TaskFunc(func(ctx context.Context) {
+		if err := s.SendVerificationEmail(user); err != nil {
+			log.Error().Err(err).Str("user_id", user.ID.String()).Msg("could not send verification email to user")
+		}
+	}))
 
 	// If a project ID is provided then link the user's organization to the project by
 	// creating a database record. This allows a path for the client to create a

--- a/pkg/quarterdeck/auth_test.go
+++ b/pkg/quarterdeck/auth_test.go
@@ -17,6 +17,7 @@ import (
 func (s *quarterdeckTestSuite) TestRegister() {
 	defer s.ResetDatabase()
 	defer mock.Reset()
+	defer s.ResetTasks()
 	require := s.Require()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -116,6 +117,7 @@ func (s *quarterdeckTestSuite) TestRegister() {
 	s.CheckError(err, http.StatusConflict, "user or organization already exists")
 
 	// Test that one verify email was sent to each user
+	s.StopTasks()
 	messages := []*mock.EmailMeta{
 		{
 			To:        "rachel@example.com",

--- a/pkg/quarterdeck/quarterdeck.go
+++ b/pkg/quarterdeck/quarterdeck.go
@@ -309,3 +309,13 @@ func (s *Server) VerifyToken(tks string) (*tokens.Claims, error) {
 	}
 	return nil, errors.New("can only use this method in test mode")
 }
+
+// Expose the task manager to the tests.
+func (s *Server) GetTaskManager() *tasks.TaskManager {
+	return s.tasks
+}
+
+// Reset the task manager from the tests.
+func (s *Server) ResetTaskManager() {
+	s.tasks = tasks.New(4, 64)
+}

--- a/pkg/quarterdeck/quarterdeck_test.go
+++ b/pkg/quarterdeck/quarterdeck_test.go
@@ -196,6 +196,17 @@ func (s *quarterdeckTestSuite) resetDatabase() (err error) {
 	return tx.Commit()
 }
 
+// Stop the task manager, waiting for all the tasks to finish. Tests should defer
+// ResetTasks() to ensure that the task manager is available to the other tests.
+func (s *quarterdeckTestSuite) StopTasks() {
+	tasks := s.srv.GetTaskManager()
+	tasks.Stop()
+}
+
+func (s *quarterdeckTestSuite) ResetTasks() {
+	s.srv.ResetTaskManager()
+}
+
 func (s *quarterdeckTestSuite) AuthContext(ctx context.Context, claims *tokens.Claims) context.Context {
 	if ctx == nil {
 		ctx = context.Background()

--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -347,7 +347,7 @@ func (s *Server) TenantStats(c *gin.Context) {
 			Count: int64(totalKeys),
 		},
 		{
-			Name:  "usage_kbytes",
+			Name:  "storage",
 			Count: 0,
 		},
 	}

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -564,7 +564,7 @@ func (suite *tenantTestSuite) TestTenantStats() {
 			Count: 0,
 		},
 		{
-			Name:  "usage_kbytes",
+			Name:  "storage",
 			Count: 0,
 		},
 	}

--- a/pkg/utils/service/service.go
+++ b/pkg/utils/service/service.go
@@ -135,8 +135,8 @@ func New(addr string, opts ...Option) *Server {
 			Addr:              addr,
 			Handler:           srv.router,
 			ErrorLog:          nil,
-			ReadHeaderTimeout: 5 * time.Second,
-			WriteTimeout:      15 * time.Second,
+			ReadHeaderTimeout: 20 * time.Second,
+			WriteTimeout:      20 * time.Second,
 			IdleTimeout:       30 * time.Second,
 		}
 	}


### PR DESCRIPTION
### Scope of changes

This updates the Quarterdeck register endpoint so that we're not blocked waiting for emails to send after the user has been created in the database.

Fixes SC-14589

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?