### PR TITLE
Rename ulid package to ulids for easier import

### DIFF
--- a/cmd/debug/main.go
+++ b/cmd/debug/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/keygen"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/utils/logger"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	ensign "github.com/rotationalio/ensign/sdks/go"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"

--- a/pkg/ensign/store/meta/keys.go
+++ b/pkg/ensign/store/meta/keys.go
@@ -3,7 +3,7 @@ package meta
 import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/ensign/store/errors"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 type IndexKey [16]byte

--- a/pkg/ensign/store/meta/keys_test.go
+++ b/pkg/ensign/store/meta/keys_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/rotationalio/ensign/pkg/ensign/store/errors"
 	"github.com/rotationalio/ensign/pkg/ensign/store/meta"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/ensign/store/meta/topics.go
+++ b/pkg/ensign/store/meta/topics.go
@@ -5,7 +5,7 @@ import (
 	api "github.com/rotationalio/ensign/pkg/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/store/errors"
 	"github.com/rotationalio/ensign/pkg/ensign/store/iterator"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	ldbiter "github.com/syndtr/goleveldb/leveldb/iterator"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"google.golang.org/protobuf/proto"

--- a/pkg/ensign/store/meta/topics_test.go
+++ b/pkg/ensign/store/meta/topics_test.go
@@ -9,7 +9,7 @@ import (
 	api "github.com/rotationalio/ensign/pkg/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/store/errors"
 	"github.com/rotationalio/ensign/pkg/ensign/store/meta"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )

--- a/pkg/quarterdeck/accounts.go
+++ b/pkg/quarterdeck/accounts.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 func (s *Server) AccountUpdate(c *gin.Context) {

--- a/pkg/quarterdeck/accounts_test.go
+++ b/pkg/quarterdeck/accounts_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 func (s *quarterdeckTestSuite) TestAccountUpdate() {

--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 //===========================================================================

--- a/pkg/quarterdeck/api/v1/api_test.go
+++ b/pkg/quarterdeck/api/v1/api_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/quarterdeck/apikeys.go
+++ b/pkg/quarterdeck/apikeys.go
@@ -14,7 +14,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/utils/pagination"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/quarterdeck/apikeys_test.go
+++ b/pkg/quarterdeck/apikeys_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
 	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 func (s *quarterdeckTestSuite) TestAPIKeyList() {

--- a/pkg/quarterdeck/auth.go
+++ b/pkg/quarterdeck/auth.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/utils/gravatar"
 	"github.com/rotationalio/ensign/pkg/utils/tasks"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/quarterdeck/auth_test.go
+++ b/pkg/quarterdeck/auth_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/utils/emails"
 	"github.com/rotationalio/ensign/pkg/utils/emails/mock"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 func (s *quarterdeckTestSuite) TestRegister() {

--- a/pkg/quarterdeck/db/models/apikeys.go
+++ b/pkg/quarterdeck/db/models/apikeys.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/keygen"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/utils/pagination"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 // APIKey is a model that represents a row in the api_keys table and provides database

--- a/pkg/quarterdeck/db/models/apikeys_test.go
+++ b/pkg/quarterdeck/db/models/apikeys_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/keygen"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/utils/pagination"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/quarterdeck/db/models/orgs.go
+++ b/pkg/quarterdeck/db/models/orgs.go
@@ -10,7 +10,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 // Organization is a model that represents a row in the organizations table and provides

--- a/pkg/quarterdeck/db/models/orgs_test.go
+++ b/pkg/quarterdeck/db/models/orgs_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/quarterdeck/db/models/users.go
+++ b/pkg/quarterdeck/db/models/users.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/utils/pagination"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 // User is a model that represents a row in the users table and provides database

--- a/pkg/quarterdeck/db/models/users_test.go
+++ b/pkg/quarterdeck/db/models/users_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/utils/pagination"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/quarterdeck/orgs.go
+++ b/pkg/quarterdeck/orgs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/quarterdeck/orgs_test.go
+++ b/pkg/quarterdeck/orgs_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 func (s *quarterdeckTestSuite) TestOrganizationDetail() {

--- a/pkg/quarterdeck/tokens/claims.go
+++ b/pkg/quarterdeck/tokens/claims.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/oklog/ulid/v2"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 // Claims implements custom claims for the Quarterdeck application.

--- a/pkg/quarterdeck/tokens/claims_test.go
+++ b/pkg/quarterdeck/tokens/claims_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/quarterdeck/users.go
+++ b/pkg/quarterdeck/users.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/utils/pagination"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/quarterdeck/users_test.go
+++ b/pkg/quarterdeck/users_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 func (s *quarterdeckTestSuite) TestUserDetail() {

--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
 	"github.com/rotationalio/ensign/pkg/utils/sendgrid"
-	"github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 
@@ -43,7 +43,7 @@ func (s *Server) Register(c *gin.Context) {
 	}
 
 	// Make the register request to Quarterdeck
-	projectID := ulid.New()
+	projectID := ulids.New()
 	req := &qd.RegisterRequest{
 		ProjectID:    projectID.String(),
 		Name:         params.Name,

--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -7,7 +7,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/vmihailenco/msgpack/v5"
 )
 

--- a/pkg/tenant/db/members_test.go
+++ b/pkg/tenant/db/members_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 	pb "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"

--- a/pkg/tenant/db/projects.go
+++ b/pkg/tenant/db/projects.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/vmihailenco/msgpack/v5"
 	"golang.org/x/net/context"
 )

--- a/pkg/tenant/db/projects_test.go
+++ b/pkg/tenant/db/projects_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 	pb "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"

--- a/pkg/tenant/db/tenants.go
+++ b/pkg/tenant/db/tenants.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/vmihailenco/msgpack/v5"
 )
 

--- a/pkg/tenant/db/tenants_test.go
+++ b/pkg/tenant/db/tenants_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 	pb "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"

--- a/pkg/tenant/db/tokens_test.go
+++ b/pkg/tenant/db/tokens_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/tenant/db/topics.go
+++ b/pkg/tenant/db/topics.go
@@ -7,7 +7,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	pb "github.com/rotationalio/ensign/pkg/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/vmihailenco/msgpack/v5"
 )
 

--- a/pkg/tenant/db/topics_test.go
+++ b/pkg/tenant/db/topics_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 	pb "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"

--- a/pkg/tenant/db/users_test.go
+++ b/pkg/tenant/db/users_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	pb "github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -7,7 +7,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/tenant/organizations.go
+++ b/pkg/tenant/organizations.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/tenant/projects.go
+++ b/pkg/tenant/projects.go
@@ -10,7 +10,7 @@ import (
 	middleware "github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/tenant/projects_test.go
+++ b/pkg/tenant/projects_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -10,7 +10,7 @@ import (
 	middleware "github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
 

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -12,7 +12,7 @@ import (
 	middleware "github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
-	ulids "github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/trisacrypto/directory/pkg/trtl/pb/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/uptime/health/health.go
+++ b/pkg/uptime/health/health.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rotationalio/ensign/pkg/uptime/db"
-	"github.com/rotationalio/ensign/pkg/utils/ulid"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
 
 // If the time between relative statuses is greater than this threshold then the status
@@ -107,7 +107,7 @@ func (h *BaseStatus) Key() ([]byte, error) {
 		h.ID = make([]byte, 32)
 		copy(h.ID[0:16], h.sid[:])
 
-		tsid := ulid.FromTime(h.Timestamp)
+		tsid := ulids.FromTime(h.Timestamp)
 		copy(h.ID[16:], tsid[:])
 	}
 	return h.ID, nil

--- a/pkg/utils/ulids/ulids.go
+++ b/pkg/utils/ulids/ulids.go
@@ -4,7 +4,7 @@ provides some common functionality (like checking if a ULID is null or is zero) 
 as a process-global, cryptographically random, monotonic, and thread-safe ulid
 generation mechanism that can be used from external packages.
 */
-package ulid
+package ulids
 
 import (
 	"crypto/rand"

--- a/pkg/utils/ulids/ulids_test.go
+++ b/pkg/utils/ulids/ulids_test.go
@@ -1,4 +1,4 @@
-package ulid_test
+package ulids_test
 
 import (
 	"sync"
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
-	ulidlib "github.com/rotationalio/ensign/pkg/utils/ulid"
+	ulidlib "github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
### Scope of changes

We generally import the `ulid` package as `ulids` to deconflict `github.com/oklog/ulid/v2` and our helper package. To make vscode work better for us, I've simply renamed this package to `ulids` and updated all the references accordingly. This should make our lives a bit easier in the future.

Fixes SC-14643

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

This is a Sunday night merge that will hopefully not be too disruptive … 