### PR TITLE
Docker compose email archive

### DIFF
--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -45,6 +45,8 @@ services:
       - quarterdeck
     ports:
       - 8080:8080
+    volumes:
+      - ./tenant/emails:/data/emails
     environment:
       - TENANT_MAINTENANCE=false
       - TENANT_BIND_ADDR=:8080
@@ -67,6 +69,7 @@ services:
       - TENANT_TOPICS_ENSIGN_CLIENT_SECRET
       - TENANT_TOPICS_ENSIGN_TOPIC
       - TENANT_SENDGRID_TESTING=true
+      - TENANT_SENDGRID_ARCHIVE=/data/emails
       - TENANT_SENDGRID_API_KEY
       - TENANT_SENDGRID_FROM_EMAIL=ensign@rotational.io
       - TENANT_SENDGRID_ADMIN_EMAIL=admins@rotational.io
@@ -93,6 +96,7 @@ services:
     volumes:
       - ./quarterdeck/db:/data/db
       - ./quarterdeck/keys:/data/keys
+      - ./quarterdeck/emails:/data/emails
     environment:
       - QUARTERDECK_MAINTENANCE=false
       - QUARTERDECK_BIND_ADDR=:8088
@@ -100,8 +104,9 @@ services:
       - QUARTERDECK_LOG_LEVEL=info
       - QUARTERDECK_CONSOLE_LOG=true
       - QUARTERDECK_ALLOW_ORIGINS=http://localhost:3000
-      - QUARTERDECK_VERIFY_BASE_URL=http://localhost:8080/verify
+      - QUARTERDECK_VERIFY_BASE_URL=http://localhost:3000/verify
       - QUARTERDECK_SENDGRID_TESTING=true
+      - QUARTERDECK_SENDGRID_ARCHIVE=/data/emails
       - QUARTERDECK_SENDGRID_API_KEY
       - QUARTERDECK_SENDGRID_FROM_EMAIL=quarterdeck@rotational.io
       - QUARTERDECK_SENDGRID_ADMIN_EMAIL=admins@rotational.io

--- a/containers/quarterdeck/.gitignore
+++ b/containers/quarterdeck/.gitignore
@@ -1,1 +1,2 @@
 db/
+emails/

--- a/containers/tenant/.gitignore
+++ b/containers/tenant/.gitignore
@@ -1,1 +1,2 @@
 db/
+emails/


### PR DESCRIPTION
### Scope of changes

This updates the docker compose configuration to dump the "sent" emails to disk so that we can view emails generated by Quarterdeck/Tenant when testing locally.

Fixes SC-14715

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [x] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

On register, you should see a verification email with a link in `containers/quarterdeck/emails`. As a temporary workaround you can make a manual request to Tenant to submit the verification token.

`curl -X POST "http://localhost:8080/v1/verify -H "Content-Type: application/json" -d '{"token": "<token>"}'`

Replace <token> with the token after the `?token=` in the email.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?