### PR TITLE
API key permissions endpoints

### DIFF
--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -32,6 +32,7 @@ type QuarterdeckClient interface {
 	APIKeyDetail(context.Context, string) (*APIKey, error)
 	APIKeyUpdate(context.Context, *APIKey) (*APIKey, error)
 	APIKeyDelete(context.Context, string) error
+	APIKeyPermissions(context.Context) ([]string, error)
 
 	// Project Resource
 	ProjectCreate(context.Context, *Project) (*Project, error)

--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -176,6 +176,19 @@ func (s *APIv1) OrganizationDetail(ctx context.Context, id string) (out *Organiz
 // API Keys Resource
 //===========================================================================
 
+func (s *APIv1) APIKeyPermissions(ctx context.Context) (out []string, err error) {
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/apikeys/permissions", nil, nil); err != nil {
+		return nil, err
+	}
+
+	if _, err = s.Do(req, &out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (s *APIv1) APIKeyList(ctx context.Context, in *APIPageQuery) (out *APIKeyList, err error) {
 	var params url.Values
 	if params, err = query.Values(in); err != nil {

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -398,6 +398,23 @@ func TestAPIKeyDelete(t *testing.T) {
 	require.NoError(t, err, "could not execute api request")
 }
 
+func TestAPIKeyPermissions(t *testing.T) {
+	// Setup the response fixture
+	fixture := []string{"topics:read", "topics:destroy"}
+
+	// Create a test server
+	ts := httptest.NewServer(testhandler(fixture, http.MethodGet, "/v1/apikeys/permissions"))
+	defer ts.Close()
+
+	// Create a client and execute endpoint request
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create api client")
+
+	rep, err := client.APIKeyPermissions(context.TODO())
+	require.NoError(t, err, "could not execute api request")
+	require.Equal(t, fixture, rep, "unexpected response returned")
+}
+
 //===========================================================================
 // Project Resource
 //===========================================================================

--- a/pkg/quarterdeck/apikeys_test.go
+++ b/pkg/quarterdeck/apikeys_test.go
@@ -391,3 +391,59 @@ func (s *quarterdeckTestSuite) TestAPIKeyDelete() {
 	err = s.client.APIKeyDelete(ctx, ulids.New().String())
 	s.CheckError(err, http.StatusNotFound, "api key not found")
 }
+
+func (s *quarterdeckTestSuite) TestAPIKeyPermissions() {
+	require := s.Require()
+	defer s.ResetDatabase()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Retrieving API Key permissions requires authentication
+	out, err := s.client.APIKeyPermissions(ctx)
+	s.CheckError(err, http.StatusUnauthorized, "this endpoint requires authentication")
+	require.Nil(out, "expected no data returned after an error")
+
+	// Create valid claims for the test user
+	claims := &tokens.Claims{
+		Name:  "Jannel P. Hudson",
+		Email: "jannel@example.com",
+	}
+	ctx = s.AuthContext(ctx, claims)
+
+	// Endpoint only returns publisher and subscriber if user has no permissions
+	expected := []string{perms.Publisher, perms.Subscriber}
+	out, err = s.client.APIKeyPermissions(ctx)
+	require.NoError(err, "should have been able to retrieve permissions")
+	require.Equal(expected, out, "expected permissions to match")
+
+	// Only topics and metrics permissions are returned
+	claims.Permissions = []string{perms.EditAPIKeys, perms.DeleteAPIKeys, perms.EditTopics}
+	ctx = s.AuthContext(ctx, claims)
+	expected = []string{perms.Publisher, perms.Subscriber, perms.EditTopics}
+	out, err = s.client.APIKeyPermissions(ctx)
+	require.NoError(err, "should have been able to retrieve permissions")
+	require.Equal(expected, out, "expected permissions to match")
+
+	// Test user with all topic and metric permissions
+	claims.Permissions = []string{
+		perms.EditAPIKeys,
+		perms.DeleteAPIKeys,
+		perms.CreateTopics,
+		perms.EditTopics,
+		perms.DestroyTopics,
+		perms.ReadMetrics,
+	}
+	ctx = s.AuthContext(ctx, claims)
+	expected = []string{
+		perms.Publisher,
+		perms.Subscriber,
+		perms.CreateTopics,
+		perms.EditTopics,
+		perms.DestroyTopics,
+		perms.ReadMetrics,
+	}
+	out, err = s.client.APIKeyPermissions(ctx)
+	require.NoError(err, "should have been able to retrieve permissions")
+	require.Equal(expected, out, "expected permissions to match")
+}

--- a/pkg/quarterdeck/apikeys_test.go
+++ b/pkg/quarterdeck/apikeys_test.go
@@ -420,7 +420,7 @@ func (s *quarterdeckTestSuite) TestAPIKeyPermissions() {
 	// Only topics and metrics permissions are returned
 	claims.Permissions = []string{perms.EditAPIKeys, perms.DeleteAPIKeys, perms.EditTopics}
 	ctx = s.AuthContext(ctx, claims)
-	expected = []string{perms.Publisher, perms.Subscriber, perms.EditTopics}
+	expected = []string{perms.EditTopics, perms.Publisher, perms.Subscriber}
 	out, err = s.client.APIKeyPermissions(ctx)
 	require.NoError(err, "should have been able to retrieve permissions")
 	require.Equal(expected, out, "expected permissions to match")
@@ -436,12 +436,12 @@ func (s *quarterdeckTestSuite) TestAPIKeyPermissions() {
 	}
 	ctx = s.AuthContext(ctx, claims)
 	expected = []string{
-		perms.Publisher,
-		perms.Subscriber,
 		perms.CreateTopics,
 		perms.EditTopics,
 		perms.DestroyTopics,
 		perms.ReadMetrics,
+		perms.Publisher,
+		perms.Subscriber,
 	}
 	out, err = s.client.APIKeyPermissions(ctx)
 	require.NoError(err, "should have been able to retrieve permissions")

--- a/pkg/quarterdeck/quarterdeck.go
+++ b/pkg/quarterdeck/quarterdeck.go
@@ -230,6 +230,7 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 			apikeys.GET("/:id", middleware.Authorize(perms.ReadAPIKeys), s.APIKeyDetail)
 			apikeys.PUT("/:id", middleware.Authorize(perms.EditAPIKeys), s.APIKeyUpdate)
 			apikeys.DELETE("/:id", middleware.Authorize(perms.DeleteAPIKeys), s.APIKeyDelete)
+			apikeys.GET("/permissions", s.APIKeyPermissions)
 		}
 
 		// Projects Resource

--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -58,6 +58,7 @@ type TenantClient interface {
 	APIKeyDetail(ctx context.Context, id string) (*APIKey, error)
 	APIKeyUpdate(context.Context, *APIKey) (*APIKey, error)
 	APIKeyDelete(ctx context.Context, id string) error
+	APIKeyPermissions(context.Context) ([]string, error)
 }
 
 //===========================================================================

--- a/pkg/tenant/api/v1/client.go
+++ b/pkg/tenant/api/v1/client.go
@@ -801,6 +801,19 @@ func (s *APIv1) APIKeyDelete(ctx context.Context, id string) (err error) {
 	return nil
 }
 
+func (s *APIv1) APIKeyPermissions(ctx context.Context) (out []string, err error) {
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, "/v1/apikeys/permissions", nil, nil); err != nil {
+		return nil, err
+	}
+
+	if _, err = s.Do(req, &out, true); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 //===========================================================================
 // Helper Methods
 //===========================================================================

--- a/pkg/tenant/api/v1/client_test.go
+++ b/pkg/tenant/api/v1/client_test.go
@@ -1305,3 +1305,26 @@ func TestAPIKeyDelete(t *testing.T) {
 	err = client.APIKeyDelete(context.Background(), "apikey001")
 	require.NoError(t, err, "could not execute api request")
 }
+
+func TestAPIKeyPermissions(t *testing.T) {
+	fixture := []string{"topics:read", "topics:destroy"}
+
+	// Creates a test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/apikeys/permissions", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Creates a client to execute tests against the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create api client")
+
+	out, err := client.APIKeyPermissions(context.Background())
+	require.NoError(t, err, "could not execute api request")
+	require.Equal(t, fixture, out, "unexpected response error")
+}

--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -363,3 +363,31 @@ func (s *Server) APIKeyDelete(c *gin.Context) {
 
 	c.Status(http.StatusNoContent)
 }
+
+// APIKeyPermissions returns the API key permissions available to the user by
+// forwarding the request to Quarterdeck.
+//
+// Route: GET /v1/apikeys/permissions
+func (s *Server) APIKeyPermissions(c *gin.Context) {
+	var (
+		ctx context.Context
+		err error
+	)
+
+	// User credentials are required to make the Quarterdeck request
+	if ctx, err = middleware.ContextFromRequest(c); err != nil {
+		log.Error().Err(err).Msg("could not create user context from request")
+		c.JSON(http.StatusUnauthorized, api.ErrorResponse("could not fetch credentials for authenticated user"))
+		return
+	}
+
+	// Get the API key permissions from Quarterdeck
+	var perms []string
+	if perms, err = s.quarterdeck.APIKeyPermissions(ctx); err != nil {
+		log.Error().Err(err).Msg("could not get API key permissions")
+		c.JSON(qd.ErrorStatus(err), api.ErrorResponse("could not retrieve API key permissions for user"))
+		return
+	}
+
+	c.JSON(http.StatusOK, perms)
+}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -302,6 +302,7 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 			apikeys.GET("/:apiKeyID", mw.Authorize(perms.ReadAPIKeys), s.APIKeyDetail)
 			apikeys.PUT("/:apiKeyID", csrf, mw.Authorize(perms.EditAPIKeys), s.APIKeyUpdate)
 			apikeys.DELETE("/:apiKeyID", csrf, mw.Authorize(perms.DeleteAPIKeys), s.APIKeyDelete)
+			apikeys.GET("/permissions", s.APIKeyPermissions)
 		}
 	}
 


### PR DESCRIPTION
### Scope of changes

This adds endpoints to Tenant and Quarterdeck to retrieve the API key permissions available to the user. This allows the frontend to determine which permissions the user can set when creating API keys.

Fixes SC-14651

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

See checklist below

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?
- [ ] Should we create shared functionality between QD and Tenant to avoid the passthrough call?
- [ ] Should we include "descriptions" in the response (loaded from the database or map in the code) or rely on directing users to documentation?