### PR TITLE
Tenant name validation cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,8 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/gosimple/slug v1.13.1 // indirect
+	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.15.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,10 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosimple/slug v1.13.1 h1:bQ+kpX9Qa6tHRaK+fZR0A0M2Kd7Pa5eHPPsb1JpHD+Q=
+github.com/gosimple/slug v1.13.1/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
+github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
+github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -63,10 +63,7 @@ func (s *Server) Register(c *gin.Context) {
 		return
 	}
 
-	// TODO: Send verification email to the provided email address
-
-	// Create a partial member record for the new user
-	// Note: Tenant ID is not populated because it hasn't been created yet
+	// Create member model for the new user
 	member := &db.Member{
 		OrgID: reply.OrgID,
 		Name:  req.Name,
@@ -75,7 +72,7 @@ func (s *Server) Register(c *gin.Context) {
 
 	// Create a default tenant and project for the new user
 	// Note: This method returns an error if the member model is invalid
-	if err = db.CreateUserResources(ctx, projectID, member); err != nil {
+	if err = db.CreateUserResources(ctx, projectID, req.Organization, member); err != nil {
 		log.Error().Str("user_id", reply.ID.String()).Err(err).Msg("could not create default tenant and project for new user")
 		// TODO: Does this leave the user in a bad state? Can they still use the app?
 	}

--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -61,12 +62,8 @@ func (m *Member) Validate() error {
 		return ErrMissingOrgID
 	}
 
-	if m.Name == "" {
+	if strings.TrimSpace(m.Name) == "" {
 		return ErrMissingMemberName
-	}
-
-	if !alphaNum.MatchString(m.Name) {
-		return ErrInvalidMemberName
 	}
 
 	if m.Role == "" {

--- a/pkg/tenant/db/members_test.go
+++ b/pkg/tenant/db/members_test.go
@@ -66,9 +66,9 @@ func TestMemberValidation(t *testing.T) {
 	member.Name = ""
 	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberName, "expected validate to fail with missing name")
 
-	// Name with special characters is invalid
-	member.Name = "Leopold*Wentzel"
-	require.ErrorIs(t, member.Validate(), db.ErrInvalidMemberName, "expected validate to fail with invalid name")
+	// Name must have non-whitespace characters
+	member.Name = " "
+	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberName, "expected validate to fail with missing name")
 
 	// Role is required
 	member.Name = "Leopold Wentzel"

--- a/pkg/tenant/db/projects.go
+++ b/pkg/tenant/db/projects.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -59,12 +60,8 @@ func (p *Project) Validate() error {
 		return ErrMissingOrgID
 	}
 
-	if p.Name == "" {
+	if strings.TrimSpace(p.Name) == "" {
 		return ErrMissingProjectName
-	}
-
-	if !alphaNum.MatchString(p.Name) {
-		return ErrInvalidProjectName
 	}
 
 	return nil

--- a/pkg/tenant/db/projects_test.go
+++ b/pkg/tenant/db/projects_test.go
@@ -63,9 +63,9 @@ func TestProjectValidate(t *testing.T) {
 	project.Name = ""
 	require.ErrorIs(t, project.Validate(), db.ErrMissingProjectName, "expected missing name error")
 
-	// Test invalid name
-	project.Name = "Hello World;"
-	require.ErrorIs(t, project.Validate(), db.ErrInvalidProjectName, "expected invalid name error")
+	// Test name that's only whitespace
+	project.Name = " "
+	require.ErrorIs(t, project.Validate(), db.ErrMissingProjectName, "expected missing name error")
 
 	// Test valid project
 	project.Name = "Hello World"

--- a/pkg/tenant/db/tenants.go
+++ b/pkg/tenant/db/tenants.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -11,6 +12,9 @@ import (
 )
 
 const TenantNamespace = "tenants"
+
+// Tenant names must be URL safe and begin with a letter.
+var TenantNameRegex = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9.-]*$")
 
 type Tenant struct {
 	OrgID           ulid.ULID `msgpack:"org_id"`
@@ -68,7 +72,7 @@ func (t *Tenant) Validate() error {
 		return ErrMissingEnvType
 	}
 
-	if !alphaNum.MatchString(t.Name) {
+	if !TenantNameRegex.MatchString(t.Name) {
 		return ErrInvalidTenantName
 	}
 

--- a/pkg/tenant/db/topics.go
+++ b/pkg/tenant/db/topics.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"regexp"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -12,6 +13,9 @@ import (
 )
 
 const TopicNamespace = "topics"
+
+// Topic names must be URL safe and begin with a letter.
+var TopicNameRegex = regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9.-_]*$")
 
 type Topic struct {
 	OrgID              ulid.ULID                `msgpack:"org_id"`

--- a/pkg/tenant/db/users.go
+++ b/pkg/tenant/db/users.go
@@ -2,8 +2,8 @@ package db
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/gosimple/slug"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -11,7 +11,7 @@ import (
 // a partially constructed member model. This method should be called after a new user
 // has been successfully registered with Quarterdeck in order to allow the user to
 // access default resources such as the tenant and project when they login.
-func CreateUserResources(ctx context.Context, projectID ulid.ULID, member *Member) (err error) {
+func CreateUserResources(ctx context.Context, projectID ulid.ULID, orgName string, member *Member) (err error) {
 	// Ensure the user data is valid before creating anything
 	if err = member.Validate(); err != nil {
 		return err
@@ -20,7 +20,7 @@ func CreateUserResources(ctx context.Context, projectID ulid.ULID, member *Membe
 	// New user should have a tenant
 	tenant := &Tenant{
 		OrgID:           member.OrgID,
-		Name:            fmt.Sprintf("%s's Tenant", member.Name),
+		Name:            slug.Make(orgName),
 		EnvironmentType: "development",
 	}
 	if err = CreateTenant(ctx, tenant); err != nil {
@@ -37,7 +37,7 @@ func CreateUserResources(ctx context.Context, projectID ulid.ULID, member *Membe
 		ID:       projectID,
 		OrgID:    member.OrgID,
 		TenantID: tenant.ID,
-		Name:     fmt.Sprintf("%s's Project", member.Name),
+		Name:     tenant.Name,
 	}
 	if err = CreateTenantProject(ctx, project); err != nil {
 		return err

--- a/pkg/tenant/db/users_test.go
+++ b/pkg/tenant/db/users_test.go
@@ -16,6 +16,7 @@ func (s *dbTestSuite) TestCreateUserResources() {
 	ctx := context.Background()
 
 	projectID := ulids.New()
+	orgName := "Rotational Labs"
 
 	// Configure trtl to return success for all requests
 	s.mock.OnPut = func(ctx context.Context, in *pb.PutRequest) (*pb.PutReply, error) {
@@ -33,21 +34,25 @@ func (s *dbTestSuite) TestCreateUserResources() {
 		Name: "Leopold Wentzel",
 		Role: "Member",
 	}
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, member), db.ErrMissingOrgID, "expected error when orgID is missing")
+	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingOrgID, "expected error when orgID is missing")
 
 	// Should return an error if user name is missing
 	member.Name = ""
 	member.OrgID = ulid.MustParse("02ABCYAWC4PA72YC53RVXAEC67")
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, member), db.ErrMissingMemberName, "expected error when member name is missing")
+	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberName, "expected error when member name is missing")
 
 	// Should return an error if user role is missing
 	member.Name = "Leopold Wentzel"
 	member.Role = ""
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, member), db.ErrMissingMemberRole, "expected error when member role is missing")
+	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberRole, "expected error when member role is missing")
+
+	// Should return an error if the org name is empty
+	member.Role = "Member"
+	require.ErrorIs(db.CreateUserResources(ctx, projectID, "", member), db.ErrMissingTenantName, "expected error when org name is not provided")
 
 	// Succesfully creating all the required resources
 	member.Role = "Member"
-	require.NoError(db.CreateUserResources(ctx, projectID, member), "expected no error when creating user resources")
+	require.NoError(db.CreateUserResources(ctx, projectID, orgName, member), "expected no error when creating user resources")
 	require.NotEmpty(member.ID, "expected member ID to be set")
 	require.NotEmpty(member.Created, "expected created time to be set")
 	require.NotEmpty(member.Modified, "expected modified time to be set")
@@ -56,5 +61,5 @@ func (s *dbTestSuite) TestCreateUserResources() {
 	s.mock.OnPut = func(ctx context.Context, in *pb.PutRequest) (*pb.PutReply, error) {
 		return nil, status.Error(codes.Internal, "trtl error")
 	}
-	require.Error(db.CreateUserResources(ctx, projectID, member), "expected error when trtl returns an error")
+	require.Error(db.CreateUserResources(ctx, projectID, orgName, member), "expected error when trtl returns an error")
 }


### PR DESCRIPTION
### Scope of changes

This cleans up the name validation for the Tenant resource so that it matches what's defined in SC-14012. In short, member names and project names must be non-empty but tenant and topic names must match a regex pattern.

Fixes SC-14012

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?