### PR TITLE
Use quarterdeck user id as member id

### DIFF
--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -98,7 +98,6 @@ services:
       - ./quarterdeck/keys:/data/keys
       - ./quarterdeck/emails:/data/emails
     environment:
-      - QUARTERDECK_SENDGRID_TESTING=true
       - QUARTERDECK_MAINTENANCE=false
       - QUARTERDECK_BIND_ADDR=:8088
       - QUARTERDECK_MODE=debug

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -65,6 +65,7 @@ func (s *Server) Register(c *gin.Context) {
 
 	// Create member model for the new user
 	member := &db.Member{
+		ID:    reply.ID,
 		OrgID: reply.OrgID,
 		Name:  req.Name,
 		Role:  reply.Role,


### PR DESCRIPTION
### Scope of changes

This updates the Tenant register method so that the Quarterdeck user ID is used as the member ID. This fixes an issue with the Member Detail endpoint that the frontend was experiencing because it was expecting the member ID to be in the user claims.

Fixes SC-14814

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

After registering a new user the member detail endpoint should return data instead of the 404 if the user ID in the claims is used in the request.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?