### PR TITLE
Add owner to organization detail response

### DIFF
--- a/containers/docker-compose.yaml
+++ b/containers/docker-compose.yaml
@@ -98,7 +98,6 @@ services:
       - ./quarterdeck/keys:/data/keys
       - ./quarterdeck/emails:/data/emails
     environment:
-      - QUARTERDECK_SENDGRID_TESTING=true
       - QUARTERDECK_MAINTENANCE=false
       - QUARTERDECK_BIND_ADDR=:8088
       - QUARTERDECK_MODE=debug

--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -166,6 +166,7 @@ type PageQuery struct {
 type Organization struct {
 	ID       string `json:"id" uri:"id"`
 	Name     string `json:"name"`
+	Owner    string `json:"owner"`
 	Domain   string `json:"domain"`
 	Created  string `json:"created"`
 	Modified string `json:"modified"`

--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -122,12 +122,12 @@ func RetrieveMember(ctx context.Context, orgID, memberID ulid.ULID) (member *Mem
 	return member, nil
 }
 
-// ListMembers retrieves all members assigned to a tenant.
-func ListMembers(ctx context.Context, tenantID ulid.ULID) (members []*Member, err error) {
+// ListMembers retrieves all members in an organization.
+func ListMembers(ctx context.Context, orgID ulid.ULID) (members []*Member, err error) {
 	// Store the tenant ID as the prefix.
 	var prefix []byte
-	if tenantID.Compare(ulid.ULID{}) != 0 {
-		prefix = tenantID[:]
+	if orgID.Compare(ulid.ULID{}) != 0 {
+		prefix = orgID[:]
 	}
 
 	// TODO: Use the cursor directly instead of having duplicate data in memory

--- a/pkg/tenant/organizations.go
+++ b/pkg/tenant/organizations.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -9,8 +10,10 @@ import (
 	"github.com/oklog/ulid/v2"
 	qd "github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
+	"github.com/rotationalio/ensign/pkg/tenant/db"
 	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/rs/zerolog/log"
 )
@@ -61,7 +64,7 @@ func (s *Server) OrganizationDetail(c *gin.Context) {
 		return
 	}
 
-	// Build the response from the Quarter
+	// Build the response from the Quarterdeck response
 	out := &api.Organization{
 		ID:       org.ID.String(),
 		Name:     org.Name,
@@ -69,7 +72,35 @@ func (s *Server) OrganizationDetail(c *gin.Context) {
 		Created:  org.Created.Format(time.RFC3339Nano),
 		Modified: org.Modified.Format(time.RFC3339Nano),
 	}
+
+	// Get the organization owner
+	if out.Owner, err = getOwner(ctx, org); err != nil {
+		log.Error().Err(err).Str("org", org.ID.String()).Msg("could not retrieve organization owner")
+	}
+
 	c.JSON(http.StatusOK, out)
+}
+
+// Helper to fetch the owner of the organization. Since an organization can have
+// multiple owners, this method returns the first owner found.
+func getOwner(ctx context.Context, org *qd.Organization) (_ string, err error) {
+	// List the members in the organization
+	var members []*db.Member
+	if members, err = db.ListMembers(ctx, org.ID); err != nil {
+		return "", err
+	}
+
+	// Return the first owner found
+	// TODO: Once user invites are implemented, this may need to be updated to list all
+	// the owners or the original owner.
+	for _, member := range members {
+		if member.Role == permissions.RoleOwner {
+			return member.Name, nil
+		}
+	}
+
+	// Organizations should have at least one owner
+	return "", errors.New("organization has no owners")
 }
 
 // Helper to fetch the orgID from the gin context. This method also logs and returns


### PR DESCRIPTION
### Scope of changes

This adds the owner name to organization detail response in Tenant so that Beacon can display it along with the other organization data.

Fixes SC-14813

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Owner name should be added to the org detail response, or an empty string if the owner can't be retrieved.

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?