### PR TITLE
Starts to flesh out SDK docs

### DIFF
--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -19,7 +19,7 @@ Ensign is a new eventing tool that make it fast, convenient, and fun to create  
 
 ## Getting Started
 
-The first step is to get an Ensign API key by visiting [the sign-up page](https://rotational.io/ensign/). Similar to getting a developer API key for [Youtube](https://developers.google.com/youtube/v3/getting-started), [Twitter](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api) or [Data.gov](https://api.data.gov/docs/api-key/), you will need an API key to use Ensign and to follow along with the rest of this Quickstart guide.
+The first step is to get an Ensign API key by visiting [the sign-up page](https://rotational.app/). Similar to getting a developer API key for [Youtube](https://developers.google.com/youtube/v3/getting-started), [Twitter](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api) or [Data.gov](https://api.data.gov/docs/api-key/), you will need an API key to use Ensign and to follow along with the rest of this Quickstart guide.
 
 <a name="ensign-keys"></a>
 ### Ensign API Keys
@@ -46,7 +46,7 @@ If you haven't already:
 In your command line, type the following to install the ensign API, SDK, and library code for Go:
 
 ```bash
-go get -u github.com/rotationalio/ensign/sdks/go@latest
+go get -u github.com/rotationalio/go-ensign@main
 ```
 
 <a name="create-a-client"></a>

--- a/docs/content/sdk/_index.md
+++ b/docs/content/sdk/_index.md
@@ -10,8 +10,52 @@ bookSearchExclude: false
 
 # SDKs
 
-This is the primary section for Ensign users.
+Welcome Ensign user!
+
+If you're looking to figure out how to write code to connect to Ensign, you've come to the right place.
 
 <!--more-->
 
-<!-- replace this comment with the content of the article -->
+Ensign is written primarily in Go and Protocol Buffers because that's what we like, but hey, this isn't about us, it's about **you**.
+
+We want Ensign to be as accessible as possible, so we made you some SDKs 💙
+
+## Available SDKs
+
+Here is a list of the SDKs that are currently available.
+
+You should be able to install each using your usual language-specific package manager (e.g. `go get`, `pip install`, `npm install`, etc.):
+
+- [go-ensign](https://github.com/rotationalio/go-ensign)
+- [pyensign](https://github.com/rotationalio/pyensign)
+- [ensignJS](https://github.com/rotationalio/ensignjs) *Note: 🙈 this just an empty repo for now, but we're working on it!!*
+
+Each SDK is structured in a language-specific fashion and contains cross-sdk driver methods as well as tooling that may be tailored to users of specific languages.
+
+Don't see an Ensign SDK for the language you love most? Tell us (support@rotational.io), and we'll get right on it!
+
+## What's in the SDK Repos?
+
+The SDK repos above contain driver and library code for interacting with Ensign. They each have their own language-specific docs.
+
+### Common Methods
+
+Here are some of the common driver methods that all of the SDKs have in some shape or form (*there are some implementation differences due to the ways that different language handle concurrency*).
+
+- Create an open `Client` to Ensign using your [API keys]({{< ref "/getting-started#getting-started" >}})
+- Create a new `Topic` on your `Client`
+- Structure valid Ensign `Events` of various possible `MimeTypes`
+- Create a new `Publisher` on your `Client` and invoke this `Publisher`'s `Publish` method to publish an `Event` to a `Topic`
+- Create a new `Subscriber` on your `Client` and create an event stream to collect published `Events` using this `Subscriber`'s `Subscribe` method
+
+## What are these Protobuf Things?
+
+Protocol buffers are useful and help us make Ensign real fast, but we know they aren't exactly common.
+
+If you're familiar with other serialization formats like JSON and XML and are just getting up to speed with protobuf, check out [this post](https://rotational.io/blog/what-are-protocol-buffers/).
+
+If you're less familiar with serialization methods, the main thing to understand is that the protocol buffers are what define the Ensign *service*; they're a set of eventing-related rules and components that Ensign understands, and if you want to write code that interacts with Ensign, you have to explain what you want in terms of those rules and components.
+
+Protocol buffers are like a recipe for ingredients that have to be combined and baked (aka compiled) into code like a casserole before you can ~~eat~~ use it. But compiling protocol buffers is not always the easiest thing, so our SDKs libraries each have a copy of the protobufs compiled in the SDK language.
+
+You shouldn't (hopefully) have to jump through the compilation hoops &mdash; just install and import the SDK you need in the language you prefer. Hopefully this makes it as easy as possible for you!

--- a/docs/content/sdk/_index.md
+++ b/docs/content/sdk/_index.md
@@ -28,7 +28,7 @@ You should be able to install each using your usual language-specific package ma
 
 - [go-ensign](https://github.com/rotationalio/go-ensign)
 - [pyensign](https://github.com/rotationalio/pyensign)
-- [ensignJS](https://github.com/rotationalio/ensignjs) *Note: 🙈 this just an empty repo for now, but we're working on it!!*
+- [ensignJS](https://github.com/rotationalio/ensignjs) *Note: 🙈 this is just an empty repo for now, but we're working on it!!*
 
 Each SDK is structured in a language-specific fashion and contains cross-sdk driver methods as well as tooling that may be tailored to users of specific languages.
 
@@ -40,7 +40,7 @@ The SDK repos above contain driver and library code for interacting with Ensign.
 
 ### Common Methods
 
-Here are some of the common driver methods that all of the SDKs have in some shape or form (*there are some implementation differences due to the ways that different language handle concurrency*).
+Here are some of the common driver methods that all of the SDKs have in some shape or form (*there are some implementation differences due to the ways that different languages handle concurrency*).
 
 - Create an open `Client` to Ensign using your [API keys]({{< ref "/getting-started#getting-started" >}})
 - Create a new `Topic` on your `Client`
@@ -56,6 +56,6 @@ If you're familiar with other serialization formats like JSON and XML and are ju
 
 If you're less familiar with serialization methods, the main thing to understand is that the protocol buffers are what define the Ensign *service*; they're a set of eventing-related rules and components that Ensign understands, and if you want to write code that interacts with Ensign, you have to explain what you want in terms of those rules and components.
 
-Protocol buffers are like a recipe for ingredients that have to be combined and baked (aka compiled) into code like a casserole before you can ~~eat~~ use it. But compiling protocol buffers is not always the easiest thing, so our SDKs libraries each have a copy of the protobufs compiled in the SDK language.
+Protocol buffers are like a recipe for ingredients that have to be combined and baked (aka compiled) into code like a casserole before you can ~~eat~~ use it. But compiling protocol buffers is not always the easiest thing, so our SDK libraries each have a copy of the protobufs compiled in the SDK language.
 
 You shouldn't (hopefully) have to jump through the compilation hoops &mdash; just install and import the SDK you need in the language you prefer. Hopefully this makes it as easy as possible for you!


### PR DESCRIPTION
### Scope of changes

This PR starts to flesh out the Ensign SDK docs page; it's still preliminary but at least has a bit more detail now.

Fixes SC-12950

### Type of change

- [ ] new feature
- [ ] bug fix
- [x] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

If you want to see what it looks like built, you can pull my branch, `cd docs`, and build locally with `hugo serve -D`

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [x] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?