### PR TITLE
API key permissions cleanup

### DIFF
--- a/pkg/quarterdeck/apikeys.go
+++ b/pkg/quarterdeck/apikeys.go
@@ -447,7 +447,7 @@ func (s *Server) APIKeyPermissions(c *gin.Context) {
 	var (
 		err            error
 		claims         *tokens.Claims
-		allPermissions []string
+		allPermissions []models.Permission
 	)
 
 	// Fetch the user claims from the request
@@ -467,13 +467,13 @@ func (s *Server) APIKeyPermissions(c *gin.Context) {
 	// Filter other permissions based on the user's claims.
 	outf := make([]string, 0, len(allPermissions))
 	for _, permission := range allPermissions {
-		if perms.UserKeyPermission(permission) && !claims.HasPermission(permission) {
+		if permission.AllowRoles && !claims.HasPermission(permission.Name) {
 			// Do not return this permission
 			continue
 		}
 
 		// Build sorted return list for the user (note that the db query returns a sorted array)
-		outf = append(outf, permission)
+		outf = append(outf, permission.Name)
 	}
 
 	c.JSON(http.StatusOK, outf)

--- a/pkg/quarterdeck/db/models/apikeys.go
+++ b/pkg/quarterdeck/db/models/apikeys.go
@@ -487,12 +487,12 @@ func (k *APIKey) Update(ctx context.Context) (err error) {
 }
 
 const (
-	APIKeyPermissionsSQL = "SELECT name FROM permissions WHERE allow_api_keys=true ORDER BY name"
+	APIKeyPermissionsSQL = "SELECT name, allow_roles FROM permissions WHERE allow_api_keys=true ORDER BY name"
 )
 
-// Fetch all eligible API key permissions from the database as a map for quick checks.
-func GetAPIKeyPermissions(ctx context.Context) (permissions []string, err error) {
-	permissions = make([]string, 0, 7)
+// Fetch all eligible API key permissions from the database.
+func GetAPIKeyPermissions(ctx context.Context) (permissions []Permission, err error) {
+	permissions = make([]Permission, 0, 7)
 
 	var tx *sql.Tx
 	if tx, err = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
@@ -507,8 +507,8 @@ func GetAPIKeyPermissions(ctx context.Context) (permissions []string, err error)
 	defer rows.Close()
 
 	for rows.Next() {
-		var permission string
-		if err = rows.Scan(&permission); err != nil {
+		permission := Permission{AllowAPIKeys: true}
+		if err = rows.Scan(&permission.Name, &permission.AllowRoles); err != nil {
 			return nil, err
 		}
 		permissions = append(permissions, permission)

--- a/pkg/quarterdeck/db/models/apikeys_test.go
+++ b/pkg/quarterdeck/db/models/apikeys_test.go
@@ -499,6 +499,28 @@ func (m *modelTestSuite) TestAPIKeyPermissions() {
 	require.Len(permissions, 7)
 }
 
+func (m *modelTestSuite) TestGetAPIKeyPermissions() {
+	require := m.Require()
+
+	// Fetch the permissions for the user
+	permissions, err := models.GetAPIKeyPermissions(context.Background())
+	require.NoError(err, "could not fetch eligble api key permissions")
+	require.Len(permissions, 7)
+
+	// Name and allowed fields should be set
+	allowRolesTrue := 0
+	for _, p := range permissions {
+		require.NotEmpty(p.Name)
+		require.True(p.AllowAPIKeys)
+		if p.AllowRoles {
+			allowRolesTrue++
+		}
+	}
+
+	// Test that the query scan captures the AllowRoles field
+	require.Greater(allowRolesTrue, 0)
+}
+
 func (m *modelTestSuite) TestAPIKeyAddSetPermissions() {
 	require := m.Require()
 


### PR DESCRIPTION
### Scope of changes

In Quarterdeck we have an endpoint which returns the API key permissions available to the user. Previously we used on a check that wasn't necessarily consistent with the database and relied on the prefixes in the permissions. This updates the endpoint to use the fields from the database instead without introducing another database query.

Fixes SC-14753

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?