### PR TITLE
Send invite on Tenant create member

### DIFF
--- a/pkg/quarterdeck/mock/quarterdeck.go
+++ b/pkg/quarterdeck/mock/quarterdeck.go
@@ -20,6 +20,7 @@ const (
 	APIKeysEP       = "/v1/apikeys"
 	ProjectsEP      = "/v1/projects"
 	OrganizationsEP = "/v1/organizations"
+	UsersEP         = "/v1/users"
 )
 
 // Server embeds an httptest Server and provides additional methods for configuring
@@ -86,6 +87,8 @@ func (s *Server) routeRequest(w http.ResponseWriter, r *http.Request) {
 	case strings.Contains(path, ProjectsEP):
 		s.handlers[ProjectsEP](w, r)
 	case strings.Contains(path, OrganizationsEP):
+		s.handlers[path](w, r)
+	case strings.Contains(path, UsersEP):
 		s.handlers[path](w, r)
 	default:
 		w.WriteHeader(http.StatusNotFound)
@@ -228,6 +231,10 @@ func (s *Server) OnOrganizations(param string, opts ...HandlerOption) {
 	s.handlers[fullPath(OrganizationsEP, param)] = handler(opts...)
 }
 
+func (s *Server) OnUsers(param string, opts ...HandlerOption) {
+	s.handlers[fullPath(UsersEP, param)] = handler(opts...)
+}
+
 // Request counters
 func (s *Server) StatusCount() int {
 	return s.requests[StatusEP]
@@ -263,4 +270,8 @@ func (s *Server) ProjectsCount() int {
 
 func (s *Server) OrganizationsCount(param string) int {
 	return s.requests[fullPath(OrganizationsEP, param)]
+}
+
+func (s *Server) UsersCount(param string) int {
+	return s.requests[fullPath(UsersEP, param)]
 }

--- a/pkg/tenant/db/errors.go
+++ b/pkg/tenant/db/errors.go
@@ -32,6 +32,9 @@ var (
 	ErrInvalidTenantName  = errors.New("invalid tenant name")
 	ErrInvalidTopicName   = errors.New("invalid topic name")
 
+	// Database state errors
+	ErrMemberExists = errors.New("member already exists")
+
 	// Key errors
 	ErrKeyNoID      = errors.New("key does not contain an id")
 	ErrKeyWrongSize = errors.New("key is not the correct size")

--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -14,22 +13,30 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-const MembersNamespace = "members"
+const (
+	MembersNamespace       = "members"
+	MembersDefaultPageSize = 100
+)
 
 type Member struct {
-	OrgID        ulid.ULID `msgpack:"org_id"`
-	ID           ulid.ULID `msgpack:"id"`
-	Email        string    `msgpack:"email"`
-	Name         string    `msgpack:"name"`
-	Role         string    `msgpack:"role"`
-	Status       string    `msgpack:"status"`
-	Created      time.Time `msgpack:"created"`
-	Modified     time.Time `msgpack:"modified"`
-	DateAdded    time.Time `msgpack:"date_added"`
-	LastActivity time.Time `msgpack:"last_activity"`
+	OrgID        ulid.ULID    `msgpack:"org_id"`
+	ID           ulid.ULID    `msgpack:"id"`
+	Email        string       `msgpack:"email"`
+	Name         string       `msgpack:"name"`
+	Role         string       `msgpack:"role"`
+	Status       MemberStatus `msgpack:"status"`
+	Created      time.Time    `msgpack:"created"`
+	Modified     time.Time    `msgpack:"modified"`
+	DateAdded    time.Time    `msgpack:"date_added"`
+	LastActivity time.Time    `msgpack:"last_activity"`
 }
 
 type MemberStatus string
+
+const (
+	MemberStatusPending   MemberStatus = "Pending"
+	MemberStatusConfirmed MemberStatus = "Confirmed"
+)
 
 var _ Model = &Member{}
 
@@ -74,10 +81,6 @@ func (m *Member) Validate() error {
 		return ErrMissingMemberEmail
 	}
 
-	if strings.TrimSpace(m.Name) == "" {
-		return ErrMissingMemberName
-	}
-
 	if m.Role == "" {
 		return ErrMissingMemberRole
 	}
@@ -100,7 +103,7 @@ func (m *Member) ToAPI() *api.Member {
 		Email:        m.Email,
 		Name:         m.Name,
 		Role:         m.Role,
-		Status:       m.Status,
+		Status:       string(m.Status),
 		Created:      TimeToString(m.Created),
 		Modified:     TimeToString(m.Modified),
 		DateAdded:    TimeToString(m.DateAdded),
@@ -152,6 +155,11 @@ func ListMembers(ctx context.Context, orgID ulid.ULID, c *pg.Cursor) (members []
 		prefix = orgID[:]
 	}
 
+	// Check to see if a default cursor exists and create one if it does not.
+	if c == nil {
+		c = pg.New("", "", MembersDefaultPageSize)
+	}
+
 	var seekKey []byte
 	if c.EndIndex != "" {
 		var start ulid.ULID
@@ -159,11 +167,6 @@ func ListMembers(ctx context.Context, orgID ulid.ULID, c *pg.Cursor) (members []
 			return nil, nil, err
 		}
 		seekKey = start[:]
-	}
-
-	// Check to see if a default cursor exists and create one if it does not.
-	if c == nil {
-		c = pg.New("", "", 0)
 	}
 
 	if c.PageSize <= 0 {
@@ -218,5 +221,26 @@ func DeleteMember(ctx context.Context, orgID, memberID ulid.ULID) (err error) {
 	if err = Delete(ctx, member); err != nil {
 		return err
 	}
+	return nil
+}
+
+// Helper method that returns an error if an email address is invalid or already exists
+// in the organization.
+func VerifyMemberEmail(ctx context.Context, orgID ulid.ULID, email string) (err error) {
+	if email == "" {
+		return ErrMissingMemberEmail
+	}
+
+	var members []*Member
+	if members, _, err = ListMembers(ctx, orgID, nil); err != nil {
+		return err
+	}
+
+	for _, member := range members {
+		if member.Email == email {
+			return ErrMemberExists
+		}
+	}
+
 	return nil
 }

--- a/pkg/tenant/db/members_test.go
+++ b/pkg/tenant/db/members_test.go
@@ -72,16 +72,8 @@ func TestMemberValidation(t *testing.T) {
 	member.Email = ""
 	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberEmail, "expected validate to fail with missing email")
 
-	// Name is required
-	member.Email = "test@testing.com"
-	member.Name = ""
-	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberName, "expected validate to fail with missing name")
-
-	// Name must have non-whitespace characters
-	member.Name = " "
-	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberName, "expected validate to fail with missing name")
-
 	// Role is required
+	member.Email = "test@testing.com"
 	member.Name = "Leopold Wentzel"
 	member.Role = ""
 	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberRole, "expected validate to fail with missing role")
@@ -132,7 +124,7 @@ func (s *dbTestSuite) TestCreateMember() {
 		Email:  "test@testing.com",
 		Name:   "member001",
 		Role:   "Admin",
-		Status: "Confirmed",
+		Status: db.MemberStatusPending,
 	}
 
 	// Call OnPut method from mock trtl database
@@ -150,7 +142,7 @@ func (s *dbTestSuite) TestCreateMember() {
 	require.NoError(err, "could not create member")
 
 	require.NotEmpty(member.ID, "expected non-zero ulid to be populated")
-	require.Equal(member.Status, "Confirmed", "expected member to have confirmed status")
+	require.Equal(db.MemberStatusPending, member.Status, "expected member to have pending status")
 	require.NotZero(member.Created, "expected member to have a created timestamp")
 	require.Equal(member.Created, member.Modified, "expected the same created and modified timestamp")
 	require.Equal(member.Created, member.LastActivity, "expected the same created and last activity timestamp")
@@ -351,8 +343,8 @@ func (s *dbTestSuite) TestUpdateMember() {
 
 	// Should fail if member model is invalid
 	member.ID = ulid.MustParse("01GKKYAWC4PA72YC53RVXAEC67")
-	member.Name = ""
-	require.ErrorIs(db.UpdateMember(ctx, member), db.ErrMissingMemberName, "expected error for invalid member model")
+	member.Role = ""
+	require.ErrorIs(db.UpdateMember(ctx, member), db.ErrMissingMemberRole, "expected error for invalid member model")
 
 	// Test NotFound path
 	s.mock.OnPut = func(ctx context.Context, in *pb.PutRequest) (*pb.PutReply, error) {

--- a/pkg/tenant/db/users_test.go
+++ b/pkg/tenant/db/users_test.go
@@ -43,14 +43,9 @@ func (s *dbTestSuite) TestCreateUserResources() {
 	member.OrgID = ulid.MustParse("02ABCYAWC4PA72YC53RVXAEC67")
 	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberEmail, "expected error when member email is missing")
 
-	// Should return an error if user name is missing
-	member.Email = "lwentzel@email.com"
-	member.Name = ""
-	member.OrgID = ulid.MustParse("02ABCYAWC4PA72YC53RVXAEC67")
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberName, "expected error when member name is missing")
-
 	// Should return an error if user role is missing
 	member.Name = "Leopold Wentzel"
+	member.Email = "lwentzel@email.com"
 	member.Role = ""
 	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberRole, "expected error when member role is missing")
 

--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
+	qd "github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	perms "github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
@@ -73,8 +74,10 @@ func (s *Server) MemberList(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
-// MemberCreate adds a new member to an organization in the database
-// and returns a 201 StatusCreated response.
+// MemberCreate starts the team member invitation process by forwarding the request to
+// Quarterdeck. If successful, an invitation email is sent to the email address in the
+// request and a unverified member is created in Trtl, returning a 201 Created
+// response.
 //
 // Route: /member
 func (s *Server) MemberCreate(c *gin.Context) {
@@ -83,8 +86,6 @@ func (s *Server) MemberCreate(c *gin.Context) {
 		member *api.Member
 		orgID  ulid.ULID
 	)
-
-	const MemberConfirmed = "Confirmed"
 
 	// Members exist in organizations
 	if orgID = orgIDFromContext(c); ulids.IsZero(orgID) {
@@ -111,29 +112,55 @@ func (s *Server) MemberCreate(c *gin.Context) {
 		return
 	}
 
-	// Verify that a member name exists and return a 400 response if it does not.
-	if member.Name == "" {
-		c.JSON(http.StatusBadRequest, api.ErrorResponse("member name is required"))
-		return
-	}
-
 	// Verify that a member role exists and return a 400 response if it does not.
 	if member.Role == "" {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse("member role is required"))
 		return
 	}
 
+	// Validate user role
+	if !perms.IsRole(member.Role) {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse("unknown member role"))
+		return
+	}
+
+	// Email address must be unique in the organization.
+	if err = db.VerifyMemberEmail(c.Request.Context(), orgID, member.Email); err != nil {
+		if errors.Is(err, db.ErrMemberExists) {
+			c.JSON(http.StatusBadRequest, api.ErrorResponse("team member already exists with this email address"))
+			return
+		}
+
+		sentry.Error(c).Err(err).Msg("could not check team member existence")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add team member"))
+		return
+	}
+
+	// Call Quarterdeck to create and send the invite email.
+	req := &qd.UserInviteRequest{
+		Email: member.Email,
+		Role:  member.Role,
+	}
+
+	var reply *qd.UserInviteReply
+	if reply, err = s.quarterdeck.UserInvite(c.Request.Context(), req); err != nil {
+		sentry.Debug(c).Err(err).Msg("tracing quarterdeck error in tenant")
+		api.ReplyQuarterdeckError(c, err)
+		return
+	}
+
+	// Create the pending record in the database.
 	dbMember := &db.Member{
-		OrgID:  orgID,
-		Email:  member.Email,
-		Name:   member.Name,
-		Role:   member.Role,
-		Status: MemberConfirmed,
+		OrgID:  reply.OrgID,
+		ID:     reply.UserID,
+		Email:  reply.Email,
+		Role:   reply.Role,
+		Status: db.MemberStatusPending,
 	}
 
 	if err = db.CreateMember(c.Request.Context(), dbMember); err != nil {
-		sentry.Error(c).Err(err).Msg("could not create member in database")
-		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add member"))
+		sentry.Error(c).Err(err).Msg("could not create member in database after invitation")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add team member"))
 		return
 	}
 


### PR DESCRIPTION
### Scope of changes

This modifies the Tenant member create endpoint to only require the `email` and `role`, and calls Quarterdeck to send the actual invite, saving a pending record in the Tenant database.

Fixes SC-15399

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?