### PR TITLE
Tenant get invite

### DIFF
--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -16,6 +16,7 @@ type TenantClient interface {
 	Login(context.Context, *LoginRequest) (*AuthReply, error)
 	Refresh(context.Context, *RefreshRequest) (*AuthReply, error)
 	VerifyEmail(context.Context, *VerifyRequest) error
+	InvitePreview(context.Context, string) (*MemberInvitePreview, error)
 
 	OrganizationDetail(context.Context, string) (*Organization, error)
 
@@ -157,6 +158,14 @@ type AuthReply struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 	LastLogin    string `json:"last_login,omitempty"`
+}
+
+type MemberInvitePreview struct {
+	Email       string `json:"email"`
+	OrgName     string `json:"org_name"`
+	InviterName string `json:"inviter_name"`
+	Role        string `json:"role"`
+	HasAccount  bool   `json:"has_account"`
 }
 
 type PageQuery struct {

--- a/pkg/tenant/api/v1/client.go
+++ b/pkg/tenant/api/v1/client.go
@@ -152,6 +152,25 @@ func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (err error) 
 	return nil
 }
 
+func (s *APIv1) InvitePreview(ctx context.Context, token string) (out *MemberInvitePreview, err error) {
+	if token == "" {
+		return nil, ErrTokenRequired
+	}
+
+	path := fmt.Sprintf("/v1/invites/%s", token)
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodGet, path, nil, nil); err != nil {
+		return nil, err
+	}
+
+	out = &MemberInvitePreview{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (s *APIv1) OrganizationDetail(ctx context.Context, id string) (out *Organization, err error) {
 	if id == "" {
 		return nil, ErrOrganizationIDRequired

--- a/pkg/tenant/api/v1/client_test.go
+++ b/pkg/tenant/api/v1/client_test.go
@@ -246,6 +246,36 @@ func TestVerifyEmail(t *testing.T) {
 	require.NoError(t, err, "could not execute verify request")
 }
 
+func TestInvitePreview(t *testing.T) {
+	fixture := &api.MemberInvitePreview{
+		Email:       "leopold.wentzel@checkers.io",
+		OrgName:     "Checkers",
+		InviterName: "Alice Smith",
+		Role:        "Member",
+		HasAccount:  true,
+	}
+
+	// Create a test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/invites/1234", r.URL.Path)
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a client to execute tests against the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create client")
+
+	// Do the request
+	out, err := client.InvitePreview(context.Background(), "1234")
+	require.NoError(t, err, "could not execute invite preview request")
+	require.Equal(t, fixture, out, "expected the fixture to be returned")
+}
+
 func TestOrganization(t *testing.T) {
 	fixture := &api.Organization{
 		ID:       "001",

--- a/pkg/tenant/api/v1/errors.go
+++ b/pkg/tenant/api/v1/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrProjectIDRequired      = errors.New("project id is required for this endpoint")
 	ErrTenantIDRequired       = errors.New("tenant id is required for this endpoint")
 	ErrTopicIDRequired        = errors.New("topic id is required for this endpoint")
+	ErrTokenRequired          = errors.New("token is required for this endpoint")
 	ErrInvalidTenantField     = errors.New("invalid tenant field")
 	ErrInvalidUserClaims      = errors.New("user claims invalid or unavailable")
 	ErrUnparsable             = errors.New("could not parse request")

--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -476,3 +476,37 @@ func (s *Server) MemberDelete(c *gin.Context) {
 	}
 	c.Status(http.StatusOK)
 }
+
+// InvitePreview returns "preview" information about an invite given a token. This
+// endpoint must not be authenticated because unauthorized users should be able to
+// accept organization invitations. Frontends should use this endpoint to validate an
+// invitation token after the user has clicked on an invitation link in their email.
+// The preview must contain enough information so the user knows which organization
+// they are joining and also whether or not the email address is already registered to
+// an account. This allows frontends to know whether or not to prompt the user to
+// login or to create a new account.
+//
+// Route: /invites/:token
+func (s *Server) InvitePreview(c *gin.Context) {
+	var err error
+
+	token := c.Param("token")
+
+	// Call Quarterdeck to retrieve the invite preview.
+	var rep *qd.UserInvitePreview
+	if rep, err = s.quarterdeck.InvitePreview(c.Request.Context(), token); err != nil {
+		sentry.Debug(c).Err(err).Msg("tracing quarterdeck error in tenant")
+		api.ReplyQuarterdeckError(c, err)
+		return
+	}
+
+	// Create the preview response
+	out := &api.MemberInvitePreview{
+		Email:       rep.Email,
+		OrgName:     rep.OrgName,
+		InviterName: rep.InviterName,
+		Role:        rep.Role,
+		HasAccount:  rep.UserExists,
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -778,3 +778,33 @@ func (suite *tenantTestSuite) TestMemberDelete() {
 	err = suite.client.MemberDelete(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV")
 	suite.requireError(err, http.StatusNotFound, "member not found", "expected error when member ID is not found")
 }
+
+func (suite *tenantTestSuite) TestInvitePreview() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Initial Quarterdeck mock returns a valid preview
+	preview := &qd.UserInvitePreview{
+		Email:       "leopold.wentzel@gmail.com",
+		OrgName:     "Events R Us",
+		InviterName: "Geoffrey",
+		Role:        "Member",
+		UserExists:  true,
+	}
+	suite.quarterdeck.OnInvites("token1234", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(preview))
+
+	// Test successful preview request
+	rep, err := suite.client.InvitePreview(ctx, "token1234")
+	require.NoError(err, "could not get preview invite")
+	require.Equal(preview.Email, rep.Email, "expected email to match")
+	require.Equal(preview.OrgName, rep.OrgName, "expected org name to match")
+	require.Equal(preview.InviterName, rep.InviterName, "expected inviter name to match")
+	require.Equal(preview.Role, rep.Role, "expected role to match")
+	require.True(rep.HasAccount, "expected user to exist")
+
+	// Test invalid invitation response is correctly forwarded by Tenant
+	suite.quarterdeck.OnInvites("token1234", mock.UseError(http.StatusBadRequest, "invalid invitation"))
+	_, err = suite.client.InvitePreview(ctx, "token1234")
+	suite.requireError(err, http.StatusBadRequest, "invalid invitation", "expected error when token is invalid")
+}

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -262,6 +262,7 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 		v1.POST("/login", s.Login)
 		v1.POST("/refresh", s.Refresh)
 		v1.POST("/verify", s.VerifyEmail)
+		v1.GET("/invites/:token", s.InvitePreview)
 
 		// Organization API routes must be authenticated
 		organizations := v1.Group("/organization", authenticator)


### PR DESCRIPTION
### Scope of changes

This adds a Tenant route to get an invite preview from the token via a Quarterdeck request.

Fixes SC-15619

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?