### PR TITLE
Verifies org has more than 1 owner before updating role in database

### DIFF
--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -412,9 +412,9 @@ func (s *Server) MemberRoleUpdate(c *gin.Context) {
 		switch count {
 		case 0:
 			sentry.Warn(c).Err(err).Msg("could not find any owners")
-			c.JSON(http.StatusInternalServerError, api.ErrorResponse("organization must have at least one owner"))
+			c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not update member role"))
 		case 1:
-			c.JSON(http.StatusBadRequest, api.ErrorResponse("unable to change role of only owner"))
+			c.JSON(http.StatusBadRequest, api.ErrorResponse("organization must have at least one owner"))
 		}
 	}
 

--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -377,16 +377,19 @@ func (s *Server) MemberRoleUpdate(c *gin.Context) {
 		return
 	}
 
-	// Loop over dbMember and count the number of members whose role is Owner to verify that at least one Owner remains in the organization.
-	var count bool
+	// Loop over dbMember and break out of the loop if there are at least two members with the role Owner. If there is only
+	// one owner, they will not be able to change their role.
+	count := 0
 	for _, dbMember := range members {
 		if dbMember.Role == perms.RoleOwner {
-			count = true
-			break
+			count++
+			if count >= 2 {
+				break
+			}
 		}
 	}
 
-	if !count {
+	if count <= 1 {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse("organization must have at least one owner"))
 		return
 	}

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -708,12 +708,12 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 	members[0].Role = perms.RoleMember
 	members[1].Role = perms.RoleAdmin
 	_, err = suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
-	suite.requireError(err, http.StatusInternalServerError, "organization must have at least one owner", "expected error when org does not have an owner")
+	suite.requireError(err, http.StatusInternalServerError, "could not update member role", "expected error when org does not have an owner")
 
 	// Set database to have one owner. Should return an error if org does not have an owner.
 	members[0].Role = perms.RoleOwner
 	_, err = suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
-	suite.requireError(err, http.StatusBadRequest, "unable to change role of only owner", "expected error when org does not have an owner")
+	suite.requireError(err, http.StatusBadRequest, "organization must have at least one owner", "expected error when org does not have an owner")
 
 	// Set more than one member role to owner for remaining tests.
 	members[1].Role = perms.RoleOwner

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -597,11 +597,19 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 	members := []*db.Member{
 		{
 			OrgID:  orgID,
+			ID:     ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+			Email:  "test@testing.com",
+			Name:   "member001",
+			Role:   perms.RoleOwner,
+			Status: db.MemberStatusConfirmed,
+		},
+		{
+			OrgID:  orgID,
 			ID:     ulid.MustParse("01GX1FCEYW8NFYRBHAFFHWD45C"),
 			Email:  "ryan@testing.com",
 			Name:   "member002",
 			Role:   perms.RoleOwner,
-			Status: "Confirmed",
+			Status: db.MemberStatusConfirmed,
 		},
 
 		{
@@ -610,7 +618,7 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 			Email:  "wilder@testing.com",
 			Name:   "member003",
 			Role:   perms.RoleAdmin,
-			Status: "Confirmed",
+			Status: db.MemberStatusConfirmed,
 		},
 
 		{
@@ -619,7 +627,7 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 			Email:  "moore@testing.com",
 			Name:   "member004",
 			Role:   perms.RoleMember,
-			Status: "Confirmed",
+			Status: db.MemberStatusConfirmed,
 		},
 	}
 
@@ -696,13 +704,13 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 	_, err = suite.client.MemberRoleUpdate(ctx, "01GQ2XB2SCGY5RZJ1ZGYSEMNDE", &api.UpdateMemberParams{Role: perms.RoleObserver})
 	suite.requireError(err, http.StatusInternalServerError, "member id does not match id in URL", "expected error when member id does not match")
 
-	// Should return an error if org does not have an owner.
-	members[0].Role = perms.RoleMember
+	// Set database to have one owner. Should return an error if org does not have an owner.
+	members[1].Role = perms.RoleAdmin
 	_, err = suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
 	suite.requireError(err, http.StatusBadRequest, "organization must have at least one owner", "expected error when org does not have an owner")
 
-	// Set a member role in the database to owner.
-	members[0].Role = perms.RoleOwner
+	// Set more than one member role to owner for test.
+	members[1].Role = perms.RoleOwner
 	rep, err := suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
 	require.NoError(err, "could not update member role")
 	require.Equal(rep.Role, perms.RoleObserver, "expected member role to update")

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -704,12 +704,18 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 	_, err = suite.client.MemberRoleUpdate(ctx, "01GQ2XB2SCGY5RZJ1ZGYSEMNDE", &api.UpdateMemberParams{Role: perms.RoleObserver})
 	suite.requireError(err, http.StatusInternalServerError, "member id does not match id in URL", "expected error when member id does not match")
 
-	// Set database to have one owner. Should return an error if org does not have an owner.
+	// Should return an error if org does not have an owner.
+	members[0].Role = perms.RoleMember
 	members[1].Role = perms.RoleAdmin
 	_, err = suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
-	suite.requireError(err, http.StatusBadRequest, "organization must have at least one owner", "expected error when org does not have an owner")
+	suite.requireError(err, http.StatusInternalServerError, "organization must have at least one owner", "expected error when org does not have an owner")
 
-	// Set more than one member role to owner for test.
+	// Set database to have one owner. Should return an error if org does not have an owner.
+	members[0].Role = perms.RoleOwner
+	_, err = suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
+	suite.requireError(err, http.StatusBadRequest, "unable to change role of only owner", "expected error when org does not have an owner")
+
+	// Set more than one member role to owner for remaining tests.
 	members[1].Role = perms.RoleOwner
 	rep, err := suite.client.MemberRoleUpdate(ctx, "01ARZ3NDEKTSV4RRFFQ69G5FAV", &api.UpdateMemberParams{Role: perms.RoleObserver})
 	require.NoError(err, "could not update member role")


### PR DESCRIPTION
### Scope of changes

Fixes a bug that changed a member's role from `Owner` to another option in the database if there was only one `Owner` in the organization.

This was noticed in a video included with PR #381 when the only member in the org's role changed from `Owner` to `Admin`, but could not switch back from `Admin` to `Owner`,

Fixes SC-15894

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?