### PR TITLE
Change member status to uint8

### DIFF
--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -31,12 +31,21 @@ type Member struct {
 	LastActivity time.Time    `msgpack:"last_activity"`
 }
 
-type MemberStatus string
+type MemberStatus uint8
 
 const (
-	MemberStatusPending   MemberStatus = "Pending"
-	MemberStatusConfirmed MemberStatus = "Confirmed"
+	MemberStatusPending MemberStatus = iota
+	MemberStatusConfirmed
 )
+
+var MemberStatusStrings = map[MemberStatus]string{
+	MemberStatusPending:   "Pending",
+	MemberStatusConfirmed: "Confirmed",
+}
+
+func (m MemberStatus) String() string {
+	return MemberStatusStrings[m]
+}
 
 var _ Model = &Member{}
 
@@ -89,10 +98,6 @@ func (m *Member) Validate() error {
 		return ErrUnknownMemberRole
 	}
 
-	if m.Status == "" {
-		return ErrMissingMemberStatus
-	}
-
 	return nil
 }
 
@@ -103,7 +108,7 @@ func (m *Member) ToAPI() *api.Member {
 		Email:        m.Email,
 		Name:         m.Name,
 		Role:         m.Role,
-		Status:       string(m.Status),
+		Status:       m.Status.String(),
 		Created:      TimeToString(m.Created),
 		Modified:     TimeToString(m.Modified),
 		DateAdded:    TimeToString(m.DateAdded),

--- a/pkg/tenant/db/members_test.go
+++ b/pkg/tenant/db/members_test.go
@@ -24,7 +24,7 @@ func TestMemberModel(t *testing.T) {
 		Email:        "test@testing.com",
 		Name:         "member001",
 		Role:         "Admin",
-		Status:       "Confirmed",
+		Status:       db.MemberStatusConfirmed,
 		Created:      time.Unix(1670424445, 0).In(time.UTC),
 		Modified:     time.Unix(1670424445, 0).In(time.UTC),
 		LastActivity: time.Unix(1670424445, 0).In(time.UTC),
@@ -60,7 +60,7 @@ func TestMemberValidation(t *testing.T) {
 		Email:  "test@testing.com",
 		Name:   "Leopold Wentzel",
 		Role:   perms.RoleAdmin,
-		Status: "Confirmed",
+		Status: db.MemberStatusConfirmed,
 	}
 
 	// OrgID is required
@@ -82,13 +82,8 @@ func TestMemberValidation(t *testing.T) {
 	member.Role = "NotARealRole"
 	require.ErrorIs(t, member.Validate(), db.ErrUnknownMemberRole, "expected validate to fail with invalid role")
 
-	// Status is required.
-	member.Role = perms.RoleAdmin
-	member.Status = ""
-	require.ErrorIs(t, member.Validate(), db.ErrMissingMemberStatus, "expected validate to fail with missing status")
-
 	// Correct validation
-	member.Status = "Confirmed"
+	member.Role = perms.RoleAdmin
 	require.NoError(t, member.Validate(), "expected validate to succeed with required org id")
 }
 
@@ -300,7 +295,7 @@ func (s *dbTestSuite) TestUpdateMember() {
 		Email:    "test@testing.com",
 		Name:     "member001",
 		Role:     "Admin",
-		Status:   "Confirmed",
+		Status:   db.MemberStatusConfirmed,
 		Created:  time.Unix(1670424445, 0),
 		Modified: time.Unix(1670424467, 0),
 	}
@@ -351,7 +346,7 @@ func (s *dbTestSuite) TestUpdateMember() {
 	s.mock.OnPut = func(ctx context.Context, in *pb.PutRequest) (*pb.PutReply, error) {
 		return nil, status.Error(codes.NotFound, "not found")
 	}
-	req := &db.Member{OrgID: ulids.New(), ID: ulids.New(), Email: "test@testing.com", Name: "member002", Role: "Admin", Status: "Confirmed"}
+	req := &db.Member{OrgID: ulids.New(), ID: ulids.New(), Email: "test@testing.com", Name: "member002", Role: "Admin", Status: db.MemberStatusConfirmed}
 	err = db.UpdateMember(ctx, req)
 	require.ErrorIs(err, db.ErrNotFound)
 }

--- a/pkg/tenant/db/users_test.go
+++ b/pkg/tenant/db/users_test.go
@@ -34,7 +34,7 @@ func (s *dbTestSuite) TestCreateUserResources() {
 		Email:  "lwentzel@email.com",
 		Name:   "Leopold Wentzel",
 		Role:   "Member",
-		Status: "Confirmed",
+		Status: db.MemberStatusConfirmed,
 	}
 	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingOrgID, "expected error when orgID is missing")
 
@@ -49,13 +49,8 @@ func (s *dbTestSuite) TestCreateUserResources() {
 	member.Role = ""
 	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberRole, "expected error when member role is missing")
 
-	// Should return an error if the user status is missing.
-	member.Role = "Member"
-	member.Status = ""
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberStatus, "expected error when member status is missing")
-
 	// Should return an error if the org name is empty
-	member.Status = "Confirmed"
+	member.Role = "Member"
 	require.ErrorIs(db.CreateUserResources(ctx, projectID, "", member), db.ErrMissingTenantName, "expected error when org name is not provided")
 
 	// Succesfully creating all the required resources

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -299,7 +299,7 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 	require.Equal(req.Email, rep.Email, "expected member email to match")
 	require.Empty(rep.Name, "expected member name to be empty")
 	require.Equal(req.Role, rep.Role, "expected member role to match")
-	require.Equal(rep.Status, string(db.MemberStatusPending), "expected member status to be pending")
+	require.Equal(rep.Status, db.MemberStatusPending.String(), "expected member status to be pending")
 	require.NotEmpty(rep.Created, "expected created time to be populated")
 	require.NotEmpty(rep.Modified, "expected modified time to be populated")
 	require.NotEmpty(rep.LastActivity, "expected last activity time to be populated")
@@ -446,7 +446,7 @@ func (suite *tenantTestSuite) TestMemberUpdate() {
 		Email:  "test@testing.com",
 		Name:   "member001",
 		Role:   "Admin",
-		Status: "Confirmed",
+		Status: db.MemberStatusConfirmed,
 	}
 
 	// Marshal the data with msgpack
@@ -569,7 +569,7 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 		Email:  "test@testing.com",
 		Name:   "member001",
 		Role:   perms.RoleOwner,
-		Status: "Confirmed",
+		Status: db.MemberStatusConfirmed,
 	}
 
 	// Marshal the member data with msgpack.
@@ -601,7 +601,7 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 			Email:  "ryan@testing.com",
 			Name:   "member002",
 			Role:   perms.RoleOwner,
-			Status: "Confirmed",
+			Status: db.MemberStatusConfirmed,
 		},
 
 		{
@@ -610,7 +610,7 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 			Email:  "wilder@testing.com",
 			Name:   "member003",
 			Role:   perms.RoleAdmin,
-			Status: "Confirmed",
+			Status: db.MemberStatusConfirmed,
 		},
 
 		{
@@ -619,7 +619,7 @@ func (suite *tenantTestSuite) TestMemberRoleUpdate() {
 			Email:  "moore@testing.com",
 			Name:   "member004",
 			Role:   perms.RoleMember,
-			Status: "Confirmed",
+			Status: db.MemberStatusConfirmed,
 		},
 	}
 


### PR DESCRIPTION
### Scope of changes

This changes the member status constants to uint8 to reduce database storage and adds a method on the type to get the string version of the constants.

Fixes SC-15798

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?