### PR TITLE
feat: make project row clickable

### DIFF
--- a/web/beacon-app/package.json
+++ b/web/beacon-app/package.json
@@ -55,7 +55,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-tooltip": "^1.0.5",
     "@reduxjs/toolkit": "^1.9.2",
-    "@rotational/beacon-core": "^2.2.2",
+    "@rotational/beacon-core": "^2.3.1",
     "@rotational/beacon-foundation": "^2.0.1",
     "@sentry/react": "^7.37.1",
     "@sentry/tracing": "^7.33.0",

--- a/web/beacon-app/src/features/projects/components/ProjectsTable.tsx
+++ b/web/beacon-app/src/features/projects/components/ProjectsTable.tsx
@@ -1,8 +1,11 @@
 import { t } from '@lingui/macro';
 import { Table } from '@rotational/beacon-core';
-import { ErrorBoundary } from '@sentry/react';
-import { useCallback } from 'react';
+// import { ErrorBoundary } from '@sentry/react';
+import React, { useCallback, useMemo } from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 
+import { PATH_DASHBOARD } from '@/application/routes/paths';
 import { formatDate } from '@/utils/formatDate';
 
 import { Project } from '../types/Project';
@@ -11,36 +14,45 @@ type ProjectTableProps = {
   projects: Project[];
 };
 
-const initialColumns: any = [
-  { Header: t`Project Name`, accessor: 'name' },
-  {
-    Header: t`Description`,
-    accessor: (p: Project) => {
-      const description = p?.description;
-      if (!description) {
-        return '---';
-      }
-      // cut off description at 100 characters
-      return description?.length > 100 ? `${description?.slice(0, 100)}...` : description || '---';
-    },
-  },
-  {
-    Header: 'Status',
-    accessor: (p: Project) => {
-      const status = p?.status;
-      return status || '---';
-    },
-  },
-  {
-    Header: t`Date Created`,
-    accessor: (date: any) => {
-      return formatDate(new Date(date?.created));
-    },
-  },
-  // { Header: 'Actions', accessor: 'actions' },
-];
+const ProjectsTable: React.FC<ProjectTableProps> = ({ projects }) => {
+  const navigate = useNavigate();
+  const initialColumns = useMemo(
+    () => [
+      { Header: t`Project ID`, accessor: 'id' },
+      { Header: t`Project Name`, accessor: 'name' },
+      {
+        Header: t`Description`,
+        accessor: (p: Project) => {
+          const description = p?.description;
+          if (!description) {
+            return '---';
+          }
+          // cut off description at 100 characters
+          return description?.length > 100
+            ? `${description?.slice(0, 100)}...`
+            : description || '---';
+        },
+      },
+      {
+        Header: 'Status',
+        accessor: (p: Project) => {
+          const status = p?.status;
+          return status || '---';
+        },
+      },
+      {
+        Header: t`Date Created`,
+        accessor: (date: any) => {
+          return formatDate(new Date(date?.created));
+        },
+      },
+      // { Header: 'Actions', accessor: 'actions' },
+    ],
+    []
+  ) as any;
 
-function ProjectsTable({ projects }: ProjectTableProps) {
+  const initialState = { hiddenColumns: ['id'] };
+
   const handleRenameProjectClick = (projectId: string) => {
     console.log('clicked!', projectId);
   };
@@ -57,9 +69,19 @@ function ProjectsTable({ projects }: ProjectTableProps) {
     }));
   }, []);
 
+  const handleRedirection = (row: any) => {
+    if (!row?.values?.id) {
+      // add toast here
+      toast.error(
+        t`Sorry, we are having trouble redirecting you to your project. Please try again.`
+      );
+    }
+    navigate(`${PATH_DASHBOARD.PROJECTS}/${row?.values?.id}`);
+  };
+
   return (
     <div className="mx-4">
-      <ErrorBoundary
+      {/* <ErrorBoundary
         fallback={
           <div className="item-center my-auto flex w-full text-center font-bold text-danger-500">
             <p>
@@ -68,11 +90,19 @@ function ProjectsTable({ projects }: ProjectTableProps) {
             </p>
           </div>
         }
-      >
-        <Table trClassName="text-sm" columns={initialColumns} data={getProjects(projects) || []} />
-      </ErrorBoundary>
+      > */}
+      <Table
+        trClassName="text-sm"
+        columns={initialColumns}
+        initialState={initialState}
+        data={getProjects(projects) || []}
+        onRowClick={(row: any) => {
+          handleRedirection(row);
+        }}
+      />
+      {/* </ErrorBoundary> */}
     </div>
   );
-}
+};
 
 export default ProjectsTable;

--- a/web/beacon-app/src/features/projects/components/__tests__/ProjectsTable.spec.tsx
+++ b/web/beacon-app/src/features/projects/components/__tests__/ProjectsTable.spec.tsx
@@ -1,0 +1,70 @@
+// import { render } from '@testing-library/react';
+import jest from 'jest-mock';
+import React from 'react';
+import { vi } from 'vitest';
+
+import { customRender } from '../../../../utils/test-utils';
+import { Project } from '../../types/Project';
+import ProjectsTable from '../ProjectsTable';
+
+const renderComponent = (props) => {
+  return customRender(<ProjectsTable {...props} />);
+};
+vi.mock('react-router-dom', async (importOrginial: any) => ({
+  ...importOrginial,
+  useNavigate: () => jest.fn(),
+}));
+
+vi.mock('@lingui/macro', async (importOrginial: any) => ({
+  ...importOrginial,
+  t: () => jest.fn(),
+  Trans: () => jest.fn(),
+}));
+describe('ProjectsTable', () => {
+  // mock useNavigate hook
+
+  //   vi.mock('react-table', async (importOrginial: any) => ({
+  //     ...importOrginial,
+  //     useTable: () => jest.fn(),
+  //     useFilters: () => jest.fn(),
+  //     useSortBy: () => jest.fn(),
+  //     usePagination: () => jest.fn(),
+  //     Row: () => jest.fn(),
+
+  //     Column: () => jest.fn(),
+  //   }));
+
+  const MockProjectProps = {
+    projects: [
+      {
+        id: '1',
+        name: 'Project 1',
+        tenant_id: '1',
+        modified: '2021-01-01',
+        description: 'Project 1 description',
+        status: 'Active',
+        created: '2021-01-01',
+      },
+      {
+        id: '2',
+        name: 'Project 2',
+        description: 'Project 2 description',
+        status: 'Inactive',
+        created: '2021-01-02',
+      },
+    ] as Project[],
+  };
+
+  it('should render table with correct columns', () => {
+    const { container } = renderComponent(MockProjectProps);
+
+    expect(container).toMatchSnapshot();
+    // const table = screen.getByRole('table');
+    // expect(table).toBeInTheDocument();
+    // expect(screen.getByText('Project ID')).toBeInTheDocument();
+    // expect(screen.getByText('Project Name')).toBeInTheDocument();
+    // expect(screen.getByText('Description')).toBeInTheDocument();
+    // expect(screen.getByText('Status')).toBeInTheDocument();
+    // expect(screen.getByText('Date Created')).toBeInTheDocument();
+  });
+});

--- a/web/beacon-app/src/features/projects/components/__tests__/__snapshots__/ProjectsTable.spec.tsx.snap
+++ b/web/beacon-app/src/features/projects/components/__tests__/__snapshots__/ProjectsTable.spec.tsx.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1
+
+exports[`ProjectsTable > should render table with correct columns 1`] = `<div />`;

--- a/web/beacon-app/yarn.lock
+++ b/web/beacon-app/yarn.lock
@@ -3948,10 +3948,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rotational/beacon-core@^2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@rotational/beacon-core/-/beacon-core-2.2.2.tgz#7025642deb6e36d5f091eb1f8e96891199ca7d3e"
-  integrity sha512-esyS0GgeL0fJZC6I15wuFMzV0XD1liqGXk3Rg/U5C0m13OJ9ikgirBpAoKfWhJ+UoocvsPgpjU8j/GFqne/10w==
+"@rotational/beacon-core@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@rotational/beacon-core/-/beacon-core-2.3.1.tgz#ad52a32213778dde7031ebb01d4a2881c25a6b94"
+  integrity sha512-2xKz79M+TwlUFd0fDrxV1wADj/+uvxiqHpiyCewbk3NnBuetI51H6RC+CvEkxAcigtiHZrEcz7qqD/rdstRgKw==
   dependencies:
     "@radix-ui/react-avatar" "^1.0.1"
     "@radix-ui/react-toast" "^1.1.2"


### PR DESCRIPTION
### Scope of changes

I made the project row clickable, allowing users to navigate to the project page. In this PR, I added the project ID column to enable redirection, but I plan to create a new story to hide it. Additionally, I will add a hover effect to each row, enhancing user experience when browsing through the rows.

Fixes SC-XXXX

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/17092433?key=ec7fe3275e646e8e3d0faa984d9d495a

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?