### PR TITLE
Fix api key count bug

### DIFF
--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -414,7 +414,6 @@ func (s *Server) TenantStats(c *gin.Context) {
 
 		// We will always retrieve at least one page; it's possible but unlikely for a
 		// project to have more than 100 API keys.
-		totalKeys = 0
 	keysLoop:
 		for {
 			var page *qd.APIKeyList

--- a/pkg/tenant/tenants_test.go
+++ b/pkg/tenant/tenants_test.go
@@ -724,7 +724,7 @@ func (suite *tenantTestSuite) TestTenantStats() {
 	require.NoError(err, "could not get tenant stats")
 	require.Equal(expected, stats, "expected tenant stats to match")
 
-	// Retrieving tenant stats with one page of keys
+	// Return two keys for each project
 	// TODO: Testing multiple pages requires a more dynamic mock
 	keys = &qd.APIKeyList{
 		APIKeys: []*qd.APIKeyPreview{
@@ -736,7 +736,7 @@ func (suite *tenantTestSuite) TestTenantStats() {
 			},
 		},
 	}
-	expected[2].Value = 2
+	expected[2].Value = 4
 	suite.quarterdeck.OnAPIKeys("", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(keys), mock.RequireAuth())
 	stats, err = suite.client.TenantStats(ctx, tenantID)
 	require.NoError(err, "could not get tenant stats")


### PR DESCRIPTION
### Scope of changes

This fixes a bug in the TenantStats handler that only counted the API keys of the most recently created project.

Fixes SC-16789

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?