### PR TITLE
Ensure Ensign validates topic names the same way Tenant does.

### DIFF
--- a/pkg/ensign/store/errors/errors.go
+++ b/pkg/ensign/store/errors/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrTopicInvalidProjectId = &Error{"cannot parse project_id field", ErrInvalidTopic}
 	ErrTopicMissingName      = &Error{"missing name field", ErrInvalidTopic}
 	ErrTopicNameTooLong      = &Error{"topic name is too long", ErrInvalidTopic}
+	ErrInvalidTopicName      = &Error{"topic name is invalid", ErrInvalidTopic}
 	ErrTopicMissingId        = &Error{"missing id field", ErrInvalidTopic}
 	ErrTopicInvalidId        = &Error{"cannot parse id field", ErrInvalidTopic}
 	ErrTopicInvalidCreated   = &Error{"invalid created field", ErrInvalidTopic}


### PR DESCRIPTION
### Scope of changes

Adds a regular expression to Ensign to ensure it validates topic names the same way tenant does. 

Fixes SC-16877

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?