### PR TITLE
Sc-16932: fix close modal style issue 

### DIFF
--- a/web/beacon-app/package.json
+++ b/web/beacon-app/package.json
@@ -55,7 +55,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-tooltip": "^1.0.5",
     "@reduxjs/toolkit": "^1.9.2",
-    "@rotational/beacon-core": "^2.3.3",
+    "@rotational/beacon-core": "^2.3.4",
     "@rotational/beacon-foundation": "^2.0.1",
     "@sentry/react": "^7.37.1",
     "@sentry/tracing": "^7.33.0",

--- a/web/beacon-app/src/components/common/Modal/ApiKeyModal/ApiKeyModal.tsx
+++ b/web/beacon-app/src/components/common/Modal/ApiKeyModal/ApiKeyModal.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable unused-imports/no-unused-vars */
 import { Button, Modal } from '@rotational/beacon-core';
 
-import { Close as CloseIcon } from '@/components/icons/close';
 import DownloadIcon from '@/components/icons/download-icon';
 import Copy from '@/components/ui/Copy';
 import { MIME_TYPES } from '@/constants/mimeTypes';
@@ -29,11 +28,9 @@ export default function ApiKeyModal({ open, onClose, data }: ApiKeyModalProps) {
         title="Your API Key"
         containerClassName="overflow-scroll max-h-[90vh] max-w-[80vw] lg:max-w-[50vw] no-scrollbar"
         data-testid="keyCreated"
+        onClose={onClose}
       >
         <>
-          <button onClick={onClose} className="bg-transparent absolute top-4 right-4 border-none">
-            <CloseIcon className="h-4 w-4" />
-          </button>
           <div className="gap-3 space-y-5 px-8 pb-5 text-sm">
             <p className="my-3">
               <span className="font-bold text-primary-900">Sweet!</span> you&apos;ve got a brand new

--- a/web/beacon-app/src/features/members/components/CancelModal/CancelAcctModal.tsx
+++ b/web/beacon-app/src/features/members/components/CancelModal/CancelAcctModal.tsx
@@ -1,6 +1,5 @@
-import { Button, Modal } from '@rotational/beacon-core';
+import { Modal } from '@rotational/beacon-core';
 
-import { Close as CloseIcon } from '@/components/icons/close';
 interface CancelAcctModalProps {
   close: () => void;
   isOpen: boolean;
@@ -13,15 +12,9 @@ export default function CancelAcctModal({ close, isOpen }: CancelAcctModalProps)
       open={isOpen}
       containerClassName="max-w-md"
       data-testid="cancelAcctModal"
+      onClose={close}
     >
       <>
-        <Button
-          onClick={close}
-          variant="ghost"
-          className="bg-transparent absolute -right-10 top-5 border-none p-2"
-        >
-          <CloseIcon />
-        </Button>
         <p className="pb-4">
           Please contact us at <span className="font-bold">support@rotational.io</span> to cancel
           your account. Please include your name, email, and Org ID in your request to cancel your

--- a/web/beacon-app/src/features/organization/components/DeleteOrgModal/DeleteOrgModal.tsx
+++ b/web/beacon-app/src/features/organization/components/DeleteOrgModal/DeleteOrgModal.tsx
@@ -1,6 +1,4 @@
-import { Button, Modal } from '@rotational/beacon-core';
-
-import { Close as CloseIcon } from '@/components/icons/close';
+import { Modal } from '@rotational/beacon-core';
 
 interface DeleteOrgModalProps {
   close: () => void;
@@ -10,16 +8,13 @@ interface DeleteOrgModalProps {
 export default function DeleteOrgModal({ close, isOpen }: DeleteOrgModalProps) {
   return (
     <div>
-      <Modal title="Delete Organization" open={isOpen} containerClassName="relative max-w-md">
+      <Modal
+        title="Delete Organization"
+        open={isOpen}
+        onClose={close}
+        containerClassName="relative max-w-md"
+      >
         <>
-          <Button
-            onClick={close}
-            variant="ghost"
-            className="absolute top-4 right-4 border-none py-2"
-          >
-            <CloseIcon />
-          </Button>
-
           <p className="pb-4">
             Please contact us at <span className="font-bold">support@rotational.io</span> to delete
             your organization. Please include your name, email, and Org ID in your request to delete

--- a/web/beacon-app/src/features/teams/components/AddNewMember/AddNewMemberModal.tsx
+++ b/web/beacon-app/src/features/teams/components/AddNewMember/AddNewMemberModal.tsx
@@ -1,8 +1,6 @@
-import { Button, Modal } from '@rotational/beacon-core';
+import { Modal } from '@rotational/beacon-core';
 import { useEffect } from 'react';
 import { toast } from 'react-hot-toast';
-
-import { Close } from '@/components/icons/close';
 import { useCreateMember } from '@/features/members/hooks/useCreateMember';
 
 import AddNewMemberForm from './AddNewMemberForm';
@@ -45,16 +43,10 @@ function AddNewMemberModal({ onClose, isOpened }: AddNewMemberModalProps) {
         title="Invite New Team Member"
         containerClassName="overflow-scroll max-h-[100vh] max-w-[100vw] lg:max-w-[50vw] no-scrollbar"
         data-testid="memberCreationModal"
+        onClose={onClose}
       >
         <>
           <AddNewMemberForm onSubmit={handleSubmit} isSubmitting={isCreatingMember} />
-          <Button
-            onClick={onClose}
-            variant="ghost"
-            className="absolute top-2 right-2 min-h-fit min-w-fit py-2"
-          >
-            <Close className="text-primary-900" />
-          </Button>
         </>
       </Modal>
     </div>

--- a/web/beacon-app/src/features/teams/components/AddNewMember/AddNewMemberModal.tsx
+++ b/web/beacon-app/src/features/teams/components/AddNewMember/AddNewMemberModal.tsx
@@ -42,7 +42,7 @@ function AddNewMemberModal({ onClose, isOpened }: AddNewMemberModalProps) {
       <Modal
         open={isOpened}
         title="Invite New Team Member"
-        containerClassName="overflow-scroll max-h-[100vh] max-w-[100vw] lg:max-w-[50vw] no-scrollbar"
+        containerClassName="overflow-scroll max-h-[100vh] max-w-[100vw] lg:max-w-[80vw] no-scrollbar"
         data-testid="memberCreationModal"
         onClose={onClose}
       >

--- a/web/beacon-app/src/features/teams/components/AddNewMember/AddNewMemberModal.tsx
+++ b/web/beacon-app/src/features/teams/components/AddNewMember/AddNewMemberModal.tsx
@@ -1,6 +1,7 @@
 import { Modal } from '@rotational/beacon-core';
 import { useEffect } from 'react';
 import { toast } from 'react-hot-toast';
+
 import { useCreateMember } from '@/features/members/hooks/useCreateMember';
 
 import AddNewMemberForm from './AddNewMemberForm';

--- a/web/beacon-app/src/features/teams/components/DeleteMember/DeleteMemberModal.tsx
+++ b/web/beacon-app/src/features/teams/components/DeleteMember/DeleteMemberModal.tsx
@@ -1,8 +1,7 @@
-import { Button, Modal } from '@rotational/beacon-core';
+import { Modal } from '@rotational/beacon-core';
 import { useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 
-import { Close } from '@/components/icons/close';
 import { useDeleteMember } from '@/features/members/hooks/useDeleteMember';
 
 import DeleteMemberForm from './DeleteMemberForm';
@@ -54,6 +53,7 @@ function DeleteMemberModal({ onClose, onOpen }: DeleteMemberModalProps) {
         title="Remove Team Member"
         containerClassName="overflow-scroll  w-[50vh] max-h-[100vh] max-w-[100vw] lg:max-w-[50vw] no-scrollbar"
         data-testid="delete-member-modal"
+        onClose={onClose}
       >
         <>
           <DeleteMemberForm
@@ -61,13 +61,6 @@ function DeleteMemberModal({ onClose, onOpen }: DeleteMemberModalProps) {
             isSubmitting={isDeletingMember}
             initialValues={initialValues}
           />
-          <Button
-            onClick={onClose}
-            variant="ghost"
-            className="absolute top-2 right-2 min-h-fit min-w-fit py-2"
-          >
-            <Close className="text-primary-900" />
-          </Button>
         </>
       </Modal>
     </div>

--- a/web/beacon-app/yarn.lock
+++ b/web/beacon-app/yarn.lock
@@ -3948,10 +3948,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rotational/beacon-core@^2.3.3":
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/@rotational/beacon-core/-/beacon-core-2.3.3.tgz#22f96c5b761982673f653695218a5318aa7aaa77"
-  integrity sha512-AMHjFXqp2XIgObu7ZTeWCqkpkQCdvpM504q6FjlLiI0AOH4hFTmqqWiBj4XxWhlY7fD41AAOTnst5JJmCryOBQ==
+"@rotational/beacon-core@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@rotational/beacon-core/-/beacon-core-2.3.4.tgz#0cc0032c83e4f9b77721528420b8b237ea06e76e"
+  integrity sha512-t8XfZueW0mwYGEB1edCMxkcXwjicmwfd2fG+lbCZLgHVfNO+tE6lmIAiD2jVH80I4SmFtahxyXYlmXrF88KVIA==
   dependencies:
     "@radix-ui/react-avatar" "^1.0.1"
     "@radix-ui/react-toast" "^1.1.2"


### PR DESCRIPTION
### Scope of changes

This removes all hard-coded close buttons in each modal by replacing them with the built-in onClose props of the design system modal component

Fixes SC-XXXX

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria


### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?