### PR TITLE
Deprecate default project creation

### DIFF
--- a/pkg/tenant/auth_test.go
+++ b/pkg/tenant/auth_test.go
@@ -176,9 +176,9 @@ func (s *tenantTestSuite) TestRegister() {
 	err = s.client.Register(ctx, req)
 	require.NoError(err, "could not complete registration with invite token")
 
-	// Test that a tenant, member, and project were created without error
+	// Test that trtl was called the correct number of times across all register calls
 	s.StopTasks()
-	require.Equal(7, trtl.Calls[trtlmock.PutRPC], "expected 7 Put calls to trtl, 2 tenant puts (store, org_index), 3 project puts (store, org_index, object_keys), one member put for each user")
+	require.Equal(4, trtl.Calls[trtlmock.PutRPC], "expected 4 Put calls to trtl, 2 tenant puts (store, org_index), one member put for each user")
 	require.Equal(0, trtl.Calls[trtlmock.GetRPC], "expected no gets on register")
 	require.Equal(0, trtl.Calls[trtlmock.DeleteRPC], "expected no deletes on register")
 	require.Equal(1, trtl.Calls[trtlmock.CursorRPC], "expected 1 cursor call on register")

--- a/pkg/tenant/db/users.go
+++ b/pkg/tenant/db/users.go
@@ -5,15 +5,14 @@ import (
 	"time"
 
 	"github.com/gosimple/slug"
-	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 )
 
 // CreateUserResources creates all the necessary database objects for a new user given
 // a partially constructed member model. This method should be called after a new user
 // has been successfully registered with Quarterdeck in order to allow the user to
-// access default resources such as the tenant and project when they login.
-func CreateUserResources(ctx context.Context, projectID ulid.ULID, orgName string, member *Member) (err error) {
+// access default resources such as the tenant and user profile info when they login.
+func CreateUserResources(ctx context.Context, orgName string, member *Member) (err error) {
 	// Ensure the user data is valid before creating anything
 	if err = member.Validate(); err != nil {
 		return err
@@ -31,18 +30,6 @@ func CreateUserResources(ctx context.Context, projectID ulid.ULID, orgName strin
 
 	// Create the member record for the user
 	if err = CreateMember(ctx, member); err != nil {
-		return err
-	}
-
-	// New user should have a default project
-	project := &Project{
-		ID:       projectID,
-		OrgID:    member.OrgID,
-		TenantID: tenant.ID,
-		OwnerID:  member.ID,
-		Name:     tenant.Name,
-	}
-	if err = CreateTenantProject(ctx, project); err != nil {
 		return err
 	}
 

--- a/pkg/tenant/db/users_test.go
+++ b/pkg/tenant/db/users_test.go
@@ -17,7 +17,6 @@ func (s *dbTestSuite) TestCreateUserResources() {
 	require := s.Require()
 	ctx := context.Background()
 
-	projectID := ulids.New()
 	orgName := "Rotational Labs"
 
 	// Configure trtl to return success for all requests
@@ -38,25 +37,25 @@ func (s *dbTestSuite) TestCreateUserResources() {
 		Role:   "Member",
 		Status: db.MemberStatusConfirmed,
 	}
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingOrgID, "expected error when orgID is missing")
+	require.ErrorIs(db.CreateUserResources(ctx, orgName, member), db.ErrMissingOrgID, "expected error when orgID is missing")
 
 	// Should return an error if user email is missing
 	member.Email = ""
 	member.OrgID = ulid.MustParse("02ABCYAWC4PA72YC53RVXAEC67")
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberEmail, "expected error when member email is missing")
+	require.ErrorIs(db.CreateUserResources(ctx, orgName, member), db.ErrMissingMemberEmail, "expected error when member email is missing")
 
 	// Should return an error if user role is missing
 	member.Name = "Leopold Wentzel"
 	member.Email = "lwentzel@email.com"
 	member.Role = ""
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, orgName, member), db.ErrMissingMemberRole, "expected error when member role is missing")
+	require.ErrorIs(db.CreateUserResources(ctx, orgName, member), db.ErrMissingMemberRole, "expected error when member role is missing")
 
 	// Should return an error if the org name is empty
 	member.Role = "Member"
-	require.ErrorIs(db.CreateUserResources(ctx, projectID, "", member), db.ErrMissingTenantName, "expected error when org name is not provided")
+	require.ErrorIs(db.CreateUserResources(ctx, "", member), db.ErrMissingTenantName, "expected error when org name is not provided")
 
 	// Succesfully creating all the required resources
-	require.NoError(db.CreateUserResources(ctx, projectID, orgName, member), "expected no error when creating user resources")
+	require.NoError(db.CreateUserResources(ctx, orgName, member), "expected no error when creating user resources")
 	require.NotEmpty(member.ID, "expected member ID to be set")
 	require.NotEmpty(member.Created, "expected created time to be set")
 	require.NotEmpty(member.Modified, "expected modified time to be set")
@@ -65,7 +64,7 @@ func (s *dbTestSuite) TestCreateUserResources() {
 	s.mock.OnPut = func(ctx context.Context, in *pb.PutRequest) (*pb.PutReply, error) {
 		return nil, status.Error(codes.Internal, "trtl error")
 	}
-	require.Error(db.CreateUserResources(ctx, projectID, orgName, member), "expected error when trtl returns an error")
+	require.Error(db.CreateUserResources(ctx, orgName, member), "expected error when trtl returns an error")
 }
 
 func (s *dbTestSuite) TestUpdateLastLogin() {


### PR DESCRIPTION
### Scope of changes

Previously we created a default project for new users. This was because we didn't have the capability on the frontend to create projects. However now that we do, we want users to be able to create their own projects.

Fixes SC-16957

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Describe how reviewers can test this change to be sure that it works correctly. Add a checklist if possible.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?