### PR TITLE
Updates topic status

### DIFF
--- a/web/beacon-app/src/features/projects/components/TopicTable.tsx
+++ b/web/beacon-app/src/features/projects/components/TopicTable.tsx
@@ -83,7 +83,7 @@ export const TopicTable = () => {
           trClassName="text-sm"
           columns={[
             { Header: t`Topic Name`, accessor: 'topic_name' },
-            { Header: t`Status`, accessor: 'state' },
+            { Header: t`Status`, accessor: 'status' },
             { Header: t`Publishers`, accessor: 'publishers' },
             { Header: t`Subscribers`, accessor: 'subscribers' },
             { Header: t`Data Storage`, accessor: 'data' },

--- a/web/beacon-app/src/features/projects/util.ts
+++ b/web/beacon-app/src/features/projects/util.ts
@@ -29,7 +29,7 @@ export const getApiKeys = (apiKeys: any) => {
 export const getTopics = (topics: any) => {
   if (!topics?.topics || topics?.topics.length === 0) return [];
   return Object.keys(topics?.topics).map((topic) => {
-    const { id, topic_name, state, created, modified } = topics.topics[topic];
-    return { id, topic_name, state, created, modified };
+    const { id, topic_name, status, created, modified } = topics.topics[topic];
+    return { id, topic_name, status, created, modified };
   }) as any;
 };

--- a/web/beacon-app/src/features/topics/types/topicService.ts
+++ b/web/beacon-app/src/features/topics/types/topicService.ts
@@ -1,7 +1,7 @@
 export interface Topic {
   id: string;
   topic_name: string;
-  state: string;
+  status: string;
   created?: string;
   modified?: string;
 }


### PR DESCRIPTION
### Scope of changes

This updates the `Topic` by replacing `state` with `status` to match changes made to the backend in PR #487. Also, updates the topic table to display the correct status.

Note: In the Figma designs, there is an icon next to the status. This is how the status appears in the other tables in Beacon. Should the design system be updated so that the Active status for Topics shown in the screenshot below has an icon next to it?

Fixes SC-16963

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

![Ensign by Rotational Labs (14)](https://github.com/rotationalio/ensign/assets/94616884/68dcb6aa-fb24-44d0-8f31-b3087a6fc7cc)

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?