### PR TITLE
Returns topic data in table

### DIFF
--- a/web/beacon-app/src/features/projects/components/TopicTable.tsx
+++ b/web/beacon-app/src/features/projects/components/TopicTable.tsx
@@ -1,16 +1,53 @@
 import { t, Trans } from '@lingui/macro';
 import { Button, Heading, Loader, Table, Toast } from '@rotational/beacon-core';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { HelpTooltip } from '@/components/common/Tooltip/HelpTooltip';
 import { useFetchTopics } from '@/features/topics/hooks/useFetchTopics';
+import { Topic } from '@/features/topics/types/topicService';
 import { formatDate } from '@/utils/formatDate';
 
-import { getTopics } from '../util';
+import { getNormalizedDataStorage, getTopics } from '../util';
 import { NewTopicModal } from './NewTopicModal';
 
 export const TopicTable = () => {
+  const initialColumns = useMemo(
+    () => [
+      { Header: t`Topic Name`, accessor: 'topic_name' },
+      {
+        Header: t`Publishers`,
+        accessor: (t: Topic) => {
+          const publishers = t?.publishers;
+          return publishers || '---';
+        },
+      },
+      {
+        Header: t`Subscribers`,
+        accessor: (t: Topic) => {
+          const subscribers = t?.subscribers;
+          return subscribers || '---';
+        },
+      },
+      {
+        Header: t`Data Storage`,
+        accessor: (t: Topic) => {
+          const value = t?.data_storage?.value;
+          const units = t?.data_storage?.units;
+          return getNormalizedDataStorage(value, units);
+        },
+      },
+      { Header: t`Status`, accessor: 'status' },
+      {
+        Header: t`Date Created`,
+        accessor: (date: any) => {
+          return formatDate(new Date(date?.created));
+        },
+      },
+    ],
+    []
+  ) as any;
+
   const [openNewTopicModal, setOpenNewTopicModal] = useState(false);
   const handleOpenNewTopicModal = () => setOpenNewTopicModal(true);
   const handleCloseNewTopicModal = () => setOpenNewTopicModal(false);
@@ -81,19 +118,7 @@ export const TopicTable = () => {
       <div className="overflow-hidden text-sm">
         <Table
           trClassName="text-sm"
-          columns={[
-            { Header: t`Topic Name`, accessor: 'topic_name' },
-            { Header: t`Status`, accessor: 'status' },
-            { Header: t`Publishers`, accessor: 'publishers' },
-            { Header: t`Subscribers`, accessor: 'subscribers' },
-            { Header: t`Data Storage`, accessor: 'data' },
-            {
-              Header: t`Date Created`,
-              accessor: (date: any) => {
-                return formatDate(new Date(date?.created));
-              },
-            },
-          ]}
+          columns={initialColumns}
           data={getTopics(topics)}
           data-cy="topicTable"
         />

--- a/web/beacon-app/src/features/topics/types/topicService.ts
+++ b/web/beacon-app/src/features/topics/types/topicService.ts
@@ -1,9 +1,14 @@
+import { QuickViewData } from '@/hooks/useFetchQuickView/quickViewService';
+
 export interface Topic {
   id: string;
   topic_name: string;
   status: string;
   created?: string;
   modified?: string;
+  publishers?: number;
+  subscribers?: number;
+  data_storage?: QuickViewData;
 }
 
 export interface Topics {


### PR DESCRIPTION
### Scope of changes

This will display the topics data returned for `Publishers`, `Subscribers`, and `Data Storage` or `---` if no data is provided.

Note: I thought moving `Status` to the 3rd column, so that it would not come in between `Publishers` and `Subscribers`.

Fixes SC-17142

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

![Ensign by Rotational Labs (17)](https://github.com/rotationalio/ensign/assets/94616884/17b17d02-9b66-4093-ad98-b0ac9c7218eb)

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?