### PR TITLE
MetaTopic Configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/prometheus/client_golang v1.14.0
-	github.com/rotationalio/go-ensign v0.6.1-0.20230502192049-ea5288d7742c
+	github.com/rotationalio/go-ensign v0.6.1-0.20230511154101-0af7bc83d7be
 	github.com/rs/zerolog v1.29.0
 	github.com/sendgrid/rest v2.6.9+incompatible
 	github.com/sendgrid/sendgrid-go v3.12.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -364,6 +364,8 @@ github.com/rotationalio/go-ensign v0.6.1-0.20230427151058-1f32bdc8473c h1:+d06x5
 github.com/rotationalio/go-ensign v0.6.1-0.20230427151058-1f32bdc8473c/go.mod h1:/qZWtHECObSFXVm3S6OL0Xkt3iFhk4SK+f7hmLIQGn8=
 github.com/rotationalio/go-ensign v0.6.1-0.20230502192049-ea5288d7742c h1:oZCI0mlBjKDQuau3B2H850rYFaa0w+2PEnH7MpEw0Jw=
 github.com/rotationalio/go-ensign v0.6.1-0.20230502192049-ea5288d7742c/go.mod h1:/qZWtHECObSFXVm3S6OL0Xkt3iFhk4SK+f7hmLIQGn8=
+github.com/rotationalio/go-ensign v0.6.1-0.20230511154101-0af7bc83d7be h1:aJkfqeIgSb/p2QKaLLRoRXQ3hKdTi/FcJ/dTpUCbcO4=
+github.com/rotationalio/go-ensign v0.6.1-0.20230511154101-0af7bc83d7be/go.mod h1:g+T6KYImUJTM6WF9EwzqZ8YKrKR/X1Ba1H0jFkrPtt4=
 github.com/rotationalio/honu v0.3.0 h1:uqFHtWrBHfT8Dg8ClIazACCPaWHl2Zehnjs+FONb68w=
 github.com/rotationalio/honu v0.3.0/go.mod h1:IOxTHyGbkTPqRw35hhEIMmPDK/rIL3cesVpGWUR4RhE=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=

--- a/pkg/tenant/client.go
+++ b/pkg/tenant/client.go
@@ -1,6 +1,7 @@
 package tenant
 
 import (
+	"github.com/rotationalio/ensign/pkg/tenant/config"
 	sdk "github.com/rotationalio/go-ensign"
 	"github.com/rotationalio/go-ensign/auth"
 )
@@ -11,28 +12,24 @@ import (
 // permissions which requires per-rpc authentication.
 type EnsignClient struct {
 	client *sdk.Client
-	opts   *sdk.Options
+	conf   config.SDKConfig
 }
 
 // NewEnsignClient creates an Ensign client from the configuration
-func NewEnsignClient(opts *sdk.Options) (*EnsignClient, error) {
-	if opts == nil {
-		opts = sdk.NewOptions()
-	}
-
-	client, err := sdk.New(opts)
-	if err != nil {
+func NewEnsignClient(conf config.SDKConfig) (_ *EnsignClient, err error) {
+	var client *sdk.Client
+	if client, err = sdk.New(conf.ClientOptions()...); err != nil {
 		return nil, err
 	}
 
-	return &EnsignClient{client: client, opts: opts}, nil
+	return &EnsignClient{client: client, conf: conf}, nil
 }
 
 // InvokeOnce exposes a clone of the SDK client for a single call using the provided
 // token for per-rpc authentication. This should be used in request handlers where
 // Ensign requests are made on behalf of the user.
 func (c *EnsignClient) InvokeOnce(token string) *sdk.Client {
-	return c.client.WithCallOptions(auth.PerRPCToken(token, c.opts.Insecure))
+	return c.client.WithCallOptions(auth.PerRPCToken(token, c.conf.Insecure))
 }
 
 // Set an SDK client on the client for testing purposes
@@ -41,6 +38,6 @@ func (c *EnsignClient) SetClient(client *sdk.Client) {
 }
 
 // Set SDK options on the client for testing purposes
-func (c *EnsignClient) SetOpts(opts *sdk.Options) {
-	c.opts = opts
+func (c *EnsignClient) SetOpts(conf config.SDKConfig) {
+	c.conf = conf
 }

--- a/pkg/tenant/config/config_test.go
+++ b/pkg/tenant/config/config_test.go
@@ -8,47 +8,45 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rotationalio/ensign/pkg/tenant/config"
 	"github.com/rotationalio/ensign/pkg/utils/logger"
-	ensign "github.com/rotationalio/go-ensign"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
 // Test environment for all config tests that is manipulated by curEnv and setEnv
 var testEnv = map[string]string{
-	"TENANT_MAINTENANCE":                 "false",
-	"TENANT_BIND_ADDR":                   ":3636",
-	"TENANT_MODE":                        gin.TestMode,
-	"TENANT_LOG_LEVEL":                   "error",
-	"TENANT_CONSOLE_LOG":                 "true",
-	"TENANT_ALLOW_ORIGINS":               "http://localhost:8888,http://localhost:8080",
-	"TENANT_AUTH_KEYS_URL":               "http://localhost:8080/.well-known/jwks.json",
-	"TENANT_AUTH_AUDIENCE":               "audience",
-	"TENANT_AUTH_ISSUER":                 "issuer",
-	"TENANT_AUTH_COOKIE_DOMAIN":          "localhost",
-	"TENANT_DATABASE_URL":                "trtl://localhost:4436",
-	"TENANT_DATABASE_INSECURE":           "true",
-	"TENANT_DATABASE_CERT_PATH":          "path/to/certs.pem",
-	"TENANT_DATABASE_POOL_PATH":          "path/to/pool.pem",
-	"TENANT_ENSIGN_ENDPOINT":             "localhost:5356",
-	"TENANT_ENSIGN_INSECURE":             "true",
-	"TENANT_ENSIGN_NO_AUTHENTICATION":    "true",
-	"TENANT_QUARTERDECK_URL":             "https://localhost:8080",
-	"TENANT_TOPICS_ENSIGN_ENDPOINT":      "localhost:5356",
-	"TENANT_TOPICS_ENSIGN_CLIENT_ID":     "client-id",
-	"TENANT_TOPICS_ENSIGN_CLIENT_SECRET": "client-secret",
-	"TENANT_TOPICS_ENSIGN_INSECURE":      "true",
-	"TENANT_TOPICS_ENSIGN_TOPIC_ID":      "topic-id",
-	"TENANT_SENDGRID_API_KEY":            "SG.testing.123-331-test",
-	"TENANT_SENDGRID_FROM_EMAIL":         "test@example.com",
-	"TENANT_SENDGRID_ADMIN_EMAIL":        "admin@example.com",
-	"TENANT_SENDGRID_ENSIGN_LIST_ID":     "cb385e60-b43c-4db2-89ad-436ec277eacb",
-	"TENANT_SENTRY_DSN":                  "http://testing.sentry.test/1234",
-	"TENANT_SENTRY_SERVER_NAME":          "tnode",
-	"TENANT_SENTRY_ENVIRONMENT":          "testing",
-	"TENANT_SENTRY_RELEASE":              "", // This should always be empty
-	"TENANT_SENTRY_TRACK_PERFORMANCE":    "true",
-	"TENANT_SENTRY_SAMPLE_RATE":          "0.95",
-	"TENANT_SENTRY_DEBUG":                "true",
+	"TENANT_MAINTENANCE":              "false",
+	"TENANT_BIND_ADDR":                ":3636",
+	"TENANT_MODE":                     gin.TestMode,
+	"TENANT_LOG_LEVEL":                "error",
+	"TENANT_CONSOLE_LOG":              "true",
+	"TENANT_ALLOW_ORIGINS":            "http://localhost:8888,http://localhost:8080",
+	"TENANT_AUTH_KEYS_URL":            "http://localhost:8080/.well-known/jwks.json",
+	"TENANT_AUTH_AUDIENCE":            "audience",
+	"TENANT_AUTH_ISSUER":              "issuer",
+	"TENANT_AUTH_COOKIE_DOMAIN":       "localhost",
+	"TENANT_DATABASE_URL":             "trtl://localhost:4436",
+	"TENANT_DATABASE_INSECURE":        "true",
+	"TENANT_DATABASE_CERT_PATH":       "path/to/certs.pem",
+	"TENANT_DATABASE_POOL_PATH":       "path/to/pool.pem",
+	"TENANT_QUARTERDECK_URL":          "https://localhost:8080",
+	"TENANT_ENSIGN_ENDPOINT":          "localhost:5356",
+	"TENANT_ENSIGN_AUTH_URL":          "http://localhost:8080",
+	"TENANT_ENSIGN_CLIENT_ID":         "client-id",
+	"TENANT_ENSIGN_CLIENT_SECRET":     "client-secret",
+	"TENANT_ENSIGN_TOPIC_NAME":        "topic-id",
+	"TENANT_ENSIGN_INSECURE":          "true",
+	"TENANT_ENSIGN_NO_AUTHENTICATION": "true",
+	"TENANT_SENDGRID_API_KEY":         "SG.testing.123-331-test",
+	"TENANT_SENDGRID_FROM_EMAIL":      "test@example.com",
+	"TENANT_SENDGRID_ADMIN_EMAIL":     "admin@example.com",
+	"TENANT_SENDGRID_ENSIGN_LIST_ID":  "cb385e60-b43c-4db2-89ad-436ec277eacb",
+	"TENANT_SENTRY_DSN":               "http://testing.sentry.test/1234",
+	"TENANT_SENTRY_SERVER_NAME":       "tnode",
+	"TENANT_SENTRY_ENVIRONMENT":       "testing",
+	"TENANT_SENTRY_RELEASE":           "", // This should always be empty
+	"TENANT_SENTRY_TRACK_PERFORMANCE": "true",
+	"TENANT_SENTRY_SAMPLE_RATE":       "0.95",
+	"TENANT_SENTRY_DEBUG":             "true",
 }
 
 func TestConfig(t *testing.T) {
@@ -87,14 +85,14 @@ func TestConfig(t *testing.T) {
 	require.Equal(t, testEnv["TENANT_DATABASE_CERT_PATH"], conf.Database.CertPath)
 	require.Equal(t, testEnv["TENANT_DATABASE_POOL_PATH"], conf.Database.PoolPath)
 	require.Equal(t, testEnv["TENANT_ENSIGN_ENDPOINT"], conf.Ensign.Endpoint)
+	require.True(t, conf.Ensign.Enabled)
+	require.Equal(t, testEnv["TENANT_QUARTERDECK_URL"], conf.Quarterdeck.URL)
+	require.Equal(t, testEnv["TENANT_ENSIGN_ENDPOINT"], conf.Ensign.Endpoint)
+	require.Equal(t, testEnv["TENANT_ENSIGN_CLIENT_ID"], conf.Ensign.ClientID)
+	require.Equal(t, testEnv["TENANT_ENSIGN_CLIENT_SECRET"], conf.Ensign.ClientSecret)
 	require.True(t, conf.Ensign.Insecure)
 	require.True(t, conf.Ensign.NoAuthentication)
-	require.Equal(t, testEnv["TENANT_QUARTERDECK_URL"], conf.Quarterdeck.URL)
-	require.Equal(t, testEnv["TENANT_TOPICS_ENSIGN_ENDPOINT"], conf.Topics.Ensign.Endpoint)
-	require.Equal(t, testEnv["TENANT_TOPICS_ENSIGN_CLIENT_ID"], conf.Topics.Ensign.ClientID)
-	require.Equal(t, testEnv["TENANT_TOPICS_ENSIGN_CLIENT_SECRET"], conf.Topics.Ensign.ClientSecret)
-	require.True(t, conf.Topics.Ensign.Insecure)
-	require.Equal(t, testEnv["TENANT_TOPICS_TOPIC_ID"], conf.Topics.TopicID)
+	require.Equal(t, testEnv["TENANT_ENSIGN_TOPIC_NAME"], conf.Ensign.TopicName)
 	require.Equal(t, testEnv["TENANT_SENDGRID_API_KEY"], conf.SendGrid.APIKey)
 	require.Equal(t, testEnv["TENANT_SENDGRID_FROM_EMAIL"], conf.SendGrid.FromEmail)
 	require.Equal(t, testEnv["TENANT_SENDGRID_ADMIN_EMAIL"], conf.SendGrid.AdminEmail)
@@ -185,23 +183,29 @@ func TestDatabase(t *testing.T) {
 
 func TestSDK(t *testing.T) {
 	conf := &config.SDKConfig{
-		Ensign: ensign.Options{
-			Endpoint:     "ensign.io:5356",
-			Insecure:     true,
-			ClientID:     "client-id",
-			ClientSecret: "client-secret",
-		},
-		TopicID: "topic-id",
+		Enabled:      true,
+		Endpoint:     "ensign.io:5356",
+		Insecure:     true,
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		TopicName:    "topic-id",
 	}
 
+	require.Len(t, conf.ClientOptions(), 3, "config should return client options")
+
 	// Topic ID is required
-	conf.Ensign.Endpoint = "ensign.io:5356"
-	conf.TopicID = ""
-	require.EqualError(t, conf.Validate(), "invalid configuration: topic ID is required", "config should be invalid when topic ID is empty")
+	conf.Endpoint = "ensign.io:5356"
+	conf.TopicName = ""
+	require.EqualError(t, conf.Validate(), "invalid meta topic config: missing topic name", "config should be invalid when topic ID is empty")
 
 	// Valid configuration
-	conf.TopicID = "topic-id"
+	conf.TopicName = "topic-id"
 	require.NoError(t, conf.Validate(), "config should be valid when topic ID is set")
+
+	// Disabled config should be valid
+	empty := &config.SDKConfig{Enabled: false}
+	require.NoError(t, empty.Validate(), "disabled config should be valid")
+	require.Len(t, empty.ClientOptions(), 0, "disabled config should retun no options")
 }
 
 func TestQuarterdeck(t *testing.T) {

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -94,7 +94,7 @@ func (s *Server) Setup() (err error) {
 		}
 
 		// Connect to Ensign
-		if s.ensign, err = NewEnsignClient(&s.conf.Ensign); err != nil {
+		if s.ensign, err = NewEnsignClient(s.conf.Ensign); err != nil {
 			return fmt.Errorf("could not create ensign client: %w", err)
 		}
 

--- a/pkg/tenant/tenant_test.go
+++ b/pkg/tenant/tenant_test.go
@@ -91,7 +91,10 @@ func (suite *tenantTestSuite) SetupSuite() {
 		Database: config.DatabaseConfig{
 			Testing: true,
 		},
-		Ensign: sdk.Options{
+		Ensign: config.SDKConfig{
+			Enabled:          true,
+			ClientID:         "testing",
+			ClientSecret:     "testing",
 			Endpoint:         "bufconn",
 			Insecure:         true,
 			NoAuthentication: true,
@@ -123,12 +126,13 @@ func (suite *tenantTestSuite) SetupSuite() {
 	assert.NoError(err, "could not initialize the Tenant client")
 
 	// Set the Ensign client on the server
-	sdkClient := &sdk.Client{}
-	err = sdkClient.ConnectMock(suite.ensign, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	sdkClient, err := sdk.New(sdk.WithMock(suite.ensign, grpc.WithTransportCredentials(insecure.NewCredentials())))
 	assert.NoError(err, "could not connect an sdk client to the mock ensign server")
+
 	ensignClient := &tenant.EnsignClient{}
 	ensignClient.SetClient(sdkClient)
-	ensignClient.SetOpts(&conf.Ensign)
+	ensignClient.SetOpts(conf.Ensign)
+
 	suite.srv.SetEnsignClient(ensignClient)
 }
 


### PR DESCRIPTION
### Scope of changes

Adds Ensign MetaTopic configuration and updates Go SDK version. Note that we cannot use the Go SDK in Ensign because there are conflicts with the protocol buffers (sadness). 

Fixes SC-16974

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will likely be merged without review. 