### PR TITLE
MetaTopic Topic Update Events

### DIFF
--- a/pkg/utils/metatopic/metatopic.go
+++ b/pkg/utils/metatopic/metatopic.go
@@ -1,0 +1,104 @@
+package metatopic
+
+import (
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// Constants useful for creating ensign Events.
+const (
+	Mimetype      = "application/msgpack"
+	SchemaName    = "metatopic.TopicUpdate"
+	SchemaVersion = "1.0.0"
+)
+
+// This is the top-level event type that is sent on the metatopic topic. It describes an
+// update to a specific topic and provides information about the topic and how it was
+// modified, and, if available, who it was modified by.
+type TopicUpdate struct {
+	UpdateType TopicUpdateType `msgpack:"update_type"`
+	OrgID      ulid.ULID       `msgpack:"org_id,omitempty"`
+	ProjectID  ulid.ULID       `msgpack:"project_id"`
+	TopicID    ulid.ULID       `msgpack:"topic_id"`
+	ClientID   string          `msgpack:"client_id"`
+	Topic      *Topic          `msgpack:"topic,omitempty"`
+}
+
+// A non-protocol buffer representation of the Topic. In the Topic Update struct it
+// represents the modified topic (e.g. the current version of the topic).
+// TODO: add placements and types to this struct.
+type Topic struct {
+	ID        []byte    `msgpack:"id"`
+	ProjectID []byte    `msgpack:"project_id"`
+	Name      string    `msgpack:"name"`
+	ReadOnly  bool      `msgpack:"readonly"`
+	Offset    uint64    `msgpack:"offset"`
+	Shards    uint32    `msgpack:"shards"`
+	Created   time.Time `msgpack:"created"`
+	Modified  time.Time `msgpack:"modified"`
+}
+
+// The type of update made to the topic, e.g. created, modified, deleted, etc.
+type TopicUpdateType uint8
+
+const (
+	TopicUpdateUnknown TopicUpdateType = iota
+	TopicUpdateCreated
+	TopicUpdateModified
+	TopicUpdateStateChange
+	TopicUpdateDeleted
+)
+
+var topicUpdateTypeNames = []string{
+	"unknown", "created", "modified", "state_change", "deleted",
+}
+
+func (t TopicUpdateType) String() string {
+	return topicUpdateTypeNames[t]
+}
+
+func (t *TopicUpdate) Marshal() ([]byte, error) {
+	return msgpack.Marshal(t)
+}
+
+func (t *TopicUpdate) Unmarshal(data []byte) error {
+	return msgpack.Unmarshal(data, t)
+}
+
+var semver = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)
+
+// Parse the version components of the schema version to create an event version.
+func ParseVersion() (major, minor, patch uint32) {
+	if !semver.MatchString(SchemaVersion) {
+		panic("cannot parse schema version")
+	}
+
+	groups := semver.FindStringSubmatch(SchemaVersion)
+	if len(groups) != 4 {
+		panic("cannot parse schema version - not enough digits")
+	}
+
+	if num, err := strconv.ParseUint(groups[1], 10, 32); err != nil {
+		panic("could not parse major schema version component")
+	} else {
+		major = uint32(num)
+	}
+
+	if num, err := strconv.ParseUint(groups[2], 10, 32); err != nil {
+		panic("could not parse minor schema version component")
+	} else {
+		minor = uint32(num)
+	}
+
+	if num, err := strconv.ParseUint(groups[3], 10, 32); err != nil {
+		panic("could not parse patch schema version component")
+	} else {
+		patch = uint32(num)
+	}
+
+	return major, minor, patch
+}

--- a/pkg/utils/metatopic/metatopic.go
+++ b/pkg/utils/metatopic/metatopic.go
@@ -32,14 +32,24 @@ type TopicUpdate struct {
 // represents the modified topic (e.g. the current version of the topic).
 // TODO: add placements and types to this struct.
 type Topic struct {
-	ID        []byte    `msgpack:"id"`
-	ProjectID []byte    `msgpack:"project_id"`
-	Name      string    `msgpack:"name"`
-	ReadOnly  bool      `msgpack:"readonly"`
-	Offset    uint64    `msgpack:"offset"`
-	Shards    uint32    `msgpack:"shards"`
-	Created   time.Time `msgpack:"created"`
-	Modified  time.Time `msgpack:"modified"`
+	ID          []byte    `msgpack:"id"`
+	ProjectID   []byte    `msgpack:"project_id"`
+	Name        string    `msgpack:"name"`
+	ReadOnly    bool      `msgpack:"readonly"`
+	Offset      uint64    `msgpack:"offset"`
+	Shards      uint32    `msgpack:"shards"`
+	Storage     float64   `msgpack:"storage"`
+	Publishers  *Activity `msgpack:"publishers"`
+	Subscribers *Activity `msgpack:"subscribers"`
+	Created     time.Time `msgpack:"created"`
+	Modified    time.Time `msgpack:"modified"`
+}
+
+// Activity represents the number of active/inactive items in a group. The total number
+// of items in a group is the sum of active + inactive.
+type Activity struct {
+	Active   uint64 `msgpack:"active"`
+	Inactive uint64 `msgpack:"inactive"`
 }
 
 // The type of update made to the topic, e.g. created, modified, deleted, etc.
@@ -67,6 +77,18 @@ func (t *TopicUpdate) Marshal() ([]byte, error) {
 
 func (t *TopicUpdate) Unmarshal(data []byte) error {
 	return msgpack.Unmarshal(data, t)
+}
+
+func (a *Activity) Total() uint64 {
+	return a.Active + a.Inactive
+}
+
+func (a *Activity) PercentActive() float64 {
+	return float64(a.Active) / float64(a.Active+a.Inactive)
+}
+
+func (a *Activity) PercentInactive() float64 {
+	return float64(a.Inactive) / float64(a.Active+a.Inactive)
 }
 
 var semver = regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)$`)

--- a/pkg/utils/metatopic/metatopic_test.go
+++ b/pkg/utils/metatopic/metatopic_test.go
@@ -1,0 +1,72 @@
+package metatopic_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/utils/metatopic"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicUpdateSerialization(t *testing.T) {
+	orgID := ulid.Make()
+	projectID := ulid.Make()
+	topicID := ulid.Make()
+
+	tut := &metatopic.TopicUpdate{
+		UpdateType: metatopic.TopicUpdateCreated,
+		OrgID:      orgID,
+		ProjectID:  projectID,
+		TopicID:    topicID,
+		ClientID:   "testing123",
+		Topic: &metatopic.Topic{
+			ID:        topicID.Bytes(),
+			ProjectID: projectID.Bytes(),
+			Name:      "testing",
+			ReadOnly:  true,
+			Offset:    1331042,
+			Shards:    1,
+			Created:   time.Now().Truncate(1 * time.Microsecond),
+			Modified:  time.Now().Truncate(1 * time.Microsecond),
+		},
+	}
+
+	// Marshal the topic update
+	data, err := tut.Marshal()
+	require.NoError(t, err, "could not marshal topic update")
+	require.NotEmpty(t, data, "expected marshaled topic update data back")
+
+	// Unmarshal the topic update
+	cmp := &metatopic.TopicUpdate{}
+	err = cmp.Unmarshal(data)
+	require.NoError(t, err, "could not unmarshal topic update")
+
+	require.Equal(t, tut, cmp, "expected marshaled and unmarshaled structs to match")
+
+}
+
+func TestTopicUpdateType(t *testing.T) {
+	testCases := []struct {
+		tut      metatopic.TopicUpdateType
+		expected string
+	}{
+		{metatopic.TopicUpdateUnknown, "unknown"},
+		{metatopic.TopicUpdateCreated, "created"},
+		{metatopic.TopicUpdateModified, "modified"},
+		{metatopic.TopicUpdateStateChange, "state_change"},
+		{metatopic.TopicUpdateDeleted, "deleted"},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expected, tc.tut.String())
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	require.Equal(t, "1.0.0", metatopic.SchemaVersion, "version has changed test needs to be updated")
+	major, minor, patch := metatopic.ParseVersion()
+	require.Equal(t, uint32(1), major)
+	require.Equal(t, uint32(0), minor)
+	require.Equal(t, uint32(0), patch)
+}

--- a/pkg/utils/metatopic/metatopic_test.go
+++ b/pkg/utils/metatopic/metatopic_test.go
@@ -27,8 +27,17 @@ func TestTopicUpdateSerialization(t *testing.T) {
 			ReadOnly:  true,
 			Offset:    1331042,
 			Shards:    1,
-			Created:   time.Now().Truncate(1 * time.Microsecond),
-			Modified:  time.Now().Truncate(1 * time.Microsecond),
+			Storage:   16.00007915496826,
+			Publishers: &metatopic.Activity{
+				Active:   7,
+				Inactive: 28,
+			},
+			Subscribers: &metatopic.Activity{
+				Active:   23,
+				Inactive: 4,
+			},
+			Created:  time.Now().Truncate(1 * time.Microsecond),
+			Modified: time.Now().Truncate(1 * time.Microsecond),
 		},
 	}
 
@@ -61,6 +70,16 @@ func TestTopicUpdateType(t *testing.T) {
 	for _, tc := range testCases {
 		require.Equal(t, tc.expected, tc.tut.String())
 	}
+}
+
+func TestActivity(t *testing.T) {
+	things := &metatopic.Activity{
+		Active:   227,
+		Inactive: 773,
+	}
+
+	require.Equal(t, uint64(1000), things.Total())
+	require.Equal(t, 1.0, things.PercentActive()+things.PercentInactive())
 }
 
 func TestParseVersion(t *testing.T) {


### PR DESCRIPTION
### Scope of changes

Adds a TopicUpdate struct as our initial event type for metatopics. 

Fixes SC-16975

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Is this all the data that Tenant needs?

### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [ ]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?