### PR TITLE
Replaces organization with workspace

### DIFF
--- a/web/beacon-app/src/features/auth/components/Register/RegistrationForm.tsx
+++ b/web/beacon-app/src/features/auth/components/Register/RegistrationForm.tsx
@@ -139,14 +139,14 @@ function RegistrationForm({ onSubmit }: RegistrationFormProps) {
             label={
               <span className="-my-1 flex items-center gap-2">
                 <span>
-                  <Trans>Organization (required)</Trans>
+                  <Trans>Workspace (required)</Trans>
                 </span>
                 <TooltipSpan>
                   <Tooltip
                     title={
                       <span className="text-xs">
                         <Trans>
-                          Your organization allows you to collaborate with teammates and set up
+                          Your workspace allows you to collaborate with teammates and set up
                           multiple tenants and projects.
                         </Trans>
                       </span>
@@ -185,7 +185,7 @@ function RegistrationForm({ onSubmit }: RegistrationFormProps) {
                   </Tooltip>
                 </span>
               }
-              placeholder="organization name"
+              placeholder="workspace"
               fullWidth
               data-testid="domain"
               {...getFieldProps('domain')}

--- a/web/beacon-app/src/features/auth/components/Register/schemas/registrationFormValidation.ts
+++ b/web/beacon-app/src/features/auth/components/Register/schemas/registrationFormValidation.ts
@@ -19,7 +19,7 @@ const validationSchema = Yup.object().shape({
   pwcheck: Yup.string()
     .oneOf([Yup.ref('password'), null], 'The passwords must match.')
     .required('Please re-enter your password to confirm.'),
-  organization: Yup.string().required('The organization is required.'),
+  organization: Yup.string().required('The workspace is required.'),
   domain: Yup.string().required('The domain is required.'),
   terms_agreement: Yup.boolean().required('The agreement is required.'),
   invite_token: Yup.string().notRequired(),

--- a/web/beacon-app/src/features/organization/components/OrganizationTable.tsx
+++ b/web/beacon-app/src/features/organization/components/OrganizationTable.tsx
@@ -34,23 +34,21 @@ export default function OrganizationsTable() {
         <SentryErrorBoundary
           fallback={
             <div>
-              <Trans>
-                Sorry, We were unable to fetch your organizations. Please try again later.
-              </Trans>
+              <Trans>Sorry, We were unable to fetch your workspaces. Please try again later.</Trans>
             </div>
           }
         >
           <div className="rounded-lg bg-[#F7F9FB] py-2">
             <Heading as={'h2'} className="ml-4 text-lg font-bold">
-              <Trans>Organizations</Trans>
+              <Trans>Workspaces</Trans>
             </Heading>
           </div>
           <div className="overflow-hidden text-sm" data-testid="orgTable">
             <Table
               trClassName="text-sm"
               columns={[
-                { Header: t`Organization Name`, accessor: 'name' },
-                { Header: t`Organization Owner`, accessor: 'role' },
+                { Header: t`Workspace Name`, accessor: 'name' },
+                { Header: t`Workspace Owner`, accessor: 'role' },
                 { Header: t`Projects`, accessor: 'projects' },
                 {
                   Header: t`Date Created`,


### PR DESCRIPTION
### Scope of changes

Replaces `Organization` with `Workspace` in the registration form and on the profile page.

Note: The backend has not been updated, so the `User` type will continue to use `organization` for now.

Fixes SC-17393

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

<img width="1616" alt="Screenshot 2023-05-23 at 10 23 18 AM" src="https://github.com/rotationalio/ensign/assets/94616884/b860d6d6-5518-4ba3-a3c6-cf7e68b6708e">

<img width="1493" alt="Screenshot 2023-05-23 at 10 33 44 AM" src="https://github.com/rotationalio/ensign/assets/94616884/bc7ad8bc-77f2-475c-8e4a-67e37fdc7498">



### Author checklist

- [ ] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ]  I have updated the dependencies list
- [ ]  I have recompiled and included new protocol buffers to reflect changes I made
- [ ]  I have added new test fixtures as needed to support added tests
- [x]  Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x]  I have moved the associated Shortcut story to "Ready for Review"

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?