### PR TITLE
Enable Gin logging in tenant maintenance mode

### DIFF
--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -383,6 +383,7 @@ func (s *Server) MaintenanceRoutes(router *gin.Engine) (err error) {
 
 	// Application Middleware
 	middlewares := []gin.HandlerFunc{
+		logger.GinLogger(ServiceName),
 		tags,
 		tracing,
 		s.Available(),


### PR DESCRIPTION
### Scope of changes

This adds the Gin logging middleware to tenant maintenance mode so that requests are still logged in maintenance mode.

Fixes SC-17884

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

If Tenant is started in maintenance mode, requests to the JSON API are logged.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

