### PR TITLE
Add total events to meta topics

### DIFF
--- a/pkg/tenant/db/topics.go
+++ b/pkg/tenant/db/topics.go
@@ -36,6 +36,7 @@ type Topic struct {
 	ID                 ulid.ULID                `msgpack:"id"`
 	Name               string                   `msgpack:"name"`
 	State              pb.TopicTombstone_Status `msgpack:"state"`
+	Events             float64                  `msgpack:"events"`
 	Storage            float64                  `msgpack:"storage"`
 	Publishers         *metatopic.Activity      `msgpack:"publishers"`
 	Subscribers        *metatopic.Activity      `msgpack:"subscribers"`

--- a/pkg/tenant/ensign.go
+++ b/pkg/tenant/ensign.go
@@ -146,6 +146,7 @@ func (s *TopicSubscriber) performUpdate(update *metatopic.TopicUpdate) (err erro
 			ProjectID:   update.ProjectID,
 			ID:          update.TopicID,
 			Name:        update.Topic.Name,
+			Events:      update.Topic.Events,
 			Storage:     update.Topic.Storage,
 			Publishers:  update.Topic.Publishers,
 			Subscribers: update.Topic.Subscribers,
@@ -164,6 +165,8 @@ func (s *TopicSubscriber) performUpdate(update *metatopic.TopicUpdate) (err erro
 
 		// Update the modifiable fields on the topic
 		topic.Name = update.Topic.Name
+		topic.Events = update.Topic.Events
+		topic.Storage = update.Topic.Storage
 		topic.Publishers = update.Topic.Publishers
 		topic.Subscribers = update.Topic.Subscribers
 

--- a/pkg/tenant/ensign_test.go
+++ b/pkg/tenant/ensign_test.go
@@ -24,7 +24,7 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 	projectID := ulids.New()
 	topicID := ulids.New()
 
-	update := &metatopic.TopicUpdate{
+	createTopic := &metatopic.TopicUpdate{
 		UpdateType: metatopic.TopicUpdateCreated,
 		OrgID:      orgID,
 		ProjectID:  projectID,
@@ -34,6 +34,7 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 			ID:        topicID[:],
 			ProjectID: projectID[:],
 			Name:      "test-topic",
+			Events:    1000,
 			Storage:   42,
 			Publishers: &metatopic.Activity{
 				Active:   1,
@@ -46,7 +47,7 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 			Modified: time.Now(),
 		},
 	}
-	data, err := update.Marshal()
+	data, err := createTopic.Marshal()
 	require.NoError(err, "failed to marshal topic create event")
 	event := &api.Event{
 		Data:     data,
@@ -64,10 +65,27 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 	}
 	require.NoError(topicCreateEvent.Wrap(event), "failed to wrap topic create event")
 
-	update.UpdateType = metatopic.TopicUpdateModified
-	update.Topic.Publishers.Active = 2
-	update.Topic.Publishers.Inactive = 1
-	data, err = update.Marshal()
+	modifyTopic := &metatopic.TopicUpdate{
+		UpdateType: metatopic.TopicUpdateModified,
+		OrgID:      orgID,
+		ProjectID:  projectID,
+		TopicID:    topicID,
+		ClientID:   "test-client",
+		Topic: &metatopic.Topic{
+			ID:         createTopic.Topic.ID,
+			ProjectID:  createTopic.Topic.ProjectID,
+			Name:       createTopic.Topic.Name,
+			Events:     2000,
+			Storage:    84,
+			Publishers: createTopic.Topic.Publishers,
+			Subscribers: &metatopic.Activity{
+				Active: 4,
+			},
+			Created:  createTopic.Topic.Created,
+			Modified: createTopic.Topic.Modified.Add(time.Hour),
+		},
+	}
+	data, err = modifyTopic.Marshal()
 	require.NoError(err, "failed to marshal topic modified event")
 	event.Data = data
 	topicModifiedEvent := &api.EventWrapper{
@@ -77,9 +95,15 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 	}
 	require.NoError(topicModifiedEvent.Wrap(event), "failed to wrap topic modified event")
 
-	update.UpdateType = metatopic.TopicUpdateStateChange
-	update.Topic = nil
-	data, err = update.Marshal()
+	stateChange := &metatopic.TopicUpdate{
+		UpdateType: metatopic.TopicUpdateStateChange,
+		OrgID:      orgID,
+		ProjectID:  projectID,
+		TopicID:    topicID,
+		ClientID:   "test-client",
+		Topic:      nil,
+	}
+	data, err = stateChange.Marshal()
 	require.NoError(err, "failed to marshal topic state change event")
 	event.Data = data
 	topicStateChangeEvent := &api.EventWrapper{
@@ -89,9 +113,15 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 	}
 	require.NoError(topicStateChangeEvent.Wrap(event), "failed to wrap topic state change event")
 
-	update.UpdateType = metatopic.TopicUpdateDeleted
-	update.Topic = nil
-	data, err = update.Marshal()
+	deleteTopic := &metatopic.TopicUpdate{
+		UpdateType: metatopic.TopicUpdateDeleted,
+		OrgID:      orgID,
+		ProjectID:  projectID,
+		TopicID:    topicID,
+		ClientID:   "test-client",
+		Topic:      nil,
+	}
+	data, err = deleteTopic.Marshal()
 	require.NoError(err, "failed to marshal topic deleted event")
 	event.Data = data
 	topicDeletedEvent := &api.EventWrapper{
@@ -122,14 +152,60 @@ func (s *tenantTestSuite) TestTopicSubscriber() {
 		case db.TopicNamespace:
 			require.Equal(key, in.Key, "wrong key for topic put")
 
-			// TODO: Need a way to distinguish between create and update from the mock.
 			topic := &db.Topic{}
 			err = topic.UnmarshalValue(in.Value)
 			require.NoError(err, "failed to unmarshal topic value")
-			if update.Topic != nil {
-				require.Equal(update.Topic.Name, topic.Name, "wrong topic name provided to put")
-				require.Equal(update.Topic.Storage, topic.Storage, "wrong topic storage provided to put")
-				require.Equal(update.Topic.Subscribers, topic.Subscribers, "wrong topic subscribers provided to put")
+
+			// TODO: Would be nice to be able to specify different behavior for each
+			// call from the mock, rather than having to specify it here.
+			calls := trtl.Calls[mock.PutRPC]
+			switch {
+			case calls <= 3:
+				// First call should be the create.
+				if topic.Name != createTopic.Topic.Name {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic name provided to put on topic create")
+				}
+
+				if topic.Events != createTopic.Topic.Events {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic events provided to put on topic create")
+				}
+
+				if topic.Storage != createTopic.Topic.Storage {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic storage provided to put on topic create")
+				}
+
+				if topic.Subscribers.Active != createTopic.Topic.Subscribers.Active {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic subscribers provided to put on topic create")
+				}
+
+			case calls == 4:
+				// Second call should be the update.
+				if topic.Name != modifyTopic.Topic.Name {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic name provided to put on topic update")
+				}
+
+				if topic.Events != modifyTopic.Topic.Events {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic events provided to put on topic update")
+				}
+
+				if topic.Storage != modifyTopic.Topic.Storage {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic storage provided to put on topic update")
+				}
+
+				if topic.Subscribers.Active != modifyTopic.Topic.Subscribers.Active {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic subscribers provided to put on topic update")
+				}
+			case calls == 5:
+				// Third call should be the state change.
+				if topic.Name != modifyTopic.Topic.Name {
+					return nil, status.Errorf(codes.InvalidArgument, "wrong topic name provided to put on topic state change")
+				}
+
+				if topic.State != api.TopicTombstone_READONLY {
+					return nil, status.Errorf(codes.InvalidArgument, "expected topic provided to put to have readonly status on topic state change")
+				}
+			default:
+				return nil, status.Errorf(codes.InvalidArgument, "unexpected call to trtl put")
 			}
 
 			return &pb.PutReply{}, nil

--- a/pkg/utils/metatopic/errors.go
+++ b/pkg/utils/metatopic/errors.go
@@ -12,6 +12,7 @@ var (
 
 	// Topic validation errors.
 	ErrMissingName        = errors.New("missing topic name")
+	ErrInvalidEvents      = errors.New("total events must be greater than or equal to 0")
 	ErrInvalidStorage     = errors.New("data storage must be greater than or equal to 0")
 	ErrMissingPublishers  = errors.New("missing topic publishers")
 	ErrMissingSubscribers = errors.New("missing topic subscribers")

--- a/pkg/utils/metatopic/metatopic.go
+++ b/pkg/utils/metatopic/metatopic.go
@@ -39,6 +39,7 @@ type Topic struct {
 	ReadOnly    bool      `msgpack:"readonly"`
 	Offset      uint64    `msgpack:"offset"`
 	Shards      uint32    `msgpack:"shards"`
+	Events      float64   `msgpack:"events"`
 	Storage     float64   `msgpack:"storage"`
 	Publishers  *Activity `msgpack:"publishers"`
 	Subscribers *Activity `msgpack:"subscribers"`
@@ -90,6 +91,10 @@ func (t *TopicUpdate) Validate() (err error) {
 
 		if t.Topic.Name == "" {
 			return ErrMissingName
+		}
+
+		if t.Topic.Events < 0 {
+			return ErrInvalidEvents
 		}
 
 		if t.Topic.Storage < 0 {

--- a/pkg/utils/metatopic/metatopic_test.go
+++ b/pkg/utils/metatopic/metatopic_test.go
@@ -46,6 +46,10 @@ func TestValidate(t *testing.T) {
 		require.ErrorIs(t, update.Validate(), metatopic.ErrMissingName, "expected error for missing topic name for update type %s", updateType)
 
 		update.Topic.Name = "testing"
+		update.Topic.Events = -1
+		require.ErrorIs(t, update.Validate(), metatopic.ErrInvalidEvents, "expected error for invalid events for update type %s", updateType)
+
+		update.Topic.Events = 0
 		update.Topic.Storage = -1.0
 		require.ErrorIs(t, update.Validate(), metatopic.ErrInvalidStorage, "expected error for invalid storage for update type %s", updateType)
 
@@ -96,6 +100,7 @@ func TestTopicUpdateSerialization(t *testing.T) {
 			ReadOnly:  true,
 			Offset:    1331042,
 			Shards:    1,
+			Events:    1000000,
 			Storage:   16.00007915496826,
 			Publishers: &metatopic.Activity{
 				Active:   7,


### PR DESCRIPTION
### Scope of changes

This updates the meta topics to include the total number of events so that Tenant can keep track of it in trtl.

Fixes SC-19055

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

The meta topic updates should include:

- Online publishers
- Online subscribers
- Total events
- Data storage
These should be included in the updates and also snapshotted to trtl.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

