### PR TITLE
Remove quarterdeck call from tenant stats

### DIFF
--- a/pkg/quarterdeck/middleware/errors.go
+++ b/pkg/quarterdeck/middleware/errors.go
@@ -17,5 +17,5 @@ var (
 	ErrParseBearer      = errors.New("could not parse Bearer token from Authorization header")
 	ErrNoAuthorization  = errors.New("no authorization header in request")
 	ErrNoRequest        = errors.New("no request found on the context")
-	ErrRateLimit        = errors.New("rate limited reached: too many requests")
+	ErrRateLimit        = errors.New("rate limit reached: too many requests")
 )

--- a/pkg/quarterdeck/mock/quarterdeck_test.go
+++ b/pkg/quarterdeck/mock/quarterdeck_test.go
@@ -67,8 +67,8 @@ func TestMock(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, rep.StatusCode, "expected status code to be 503")
 
 	// Endpoint with a path parameter
-	quarterdeck.OnAPIKeys("somekey")
-	req, err = http.NewRequest(http.MethodPost, quarterdeck.URL()+"/v1/apikeys/somekey", nil)
+	quarterdeck.OnAPIKeysDetail("somekey")
+	req, err = http.NewRequest(http.MethodGet, quarterdeck.URL()+"/v1/apikeys/somekey", nil)
 	require.NoError(t, err, "could not create request")
 	rep, err = client.Do(req)
 	require.NoError(t, err, "could not execute request")
@@ -76,5 +76,5 @@ func TestMock(t *testing.T) {
 
 	// Verify that the handlers were called the expected number of times
 	require.Equal(t, 4, quarterdeck.StatusCount(), "expected status handler to be called 4 times")
-	require.Equal(t, 1, quarterdeck.APIKeysCount("somekey"), "expected apikeys handler to be called 1 time")
+	require.Equal(t, 1, quarterdeck.APIKeysDetailCount("somekey"), "expected apikeys handler to be called 1 time")
 }

--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -385,12 +385,25 @@ func (s *Server) APIKeyDelete(c *gin.Context) {
 	// Parse the API key ID from the URL
 	apiKeyID := c.Param("apiKeyID")
 
+	// Figure out which project this key belongs to
+	key := &qd.APIKey{}
+	if key, err = s.quarterdeck.APIKeyDetail(ctx, apiKeyID); err != nil {
+		sentry.Debug(c).Err(err).Msg("tracing quarterdeck error in tenant")
+		api.ReplyQuarterdeckError(c, err)
+		return
+	}
+
 	// Delete the API key using Quarterdeck
 	if err = s.quarterdeck.APIKeyDelete(ctx, apiKeyID); err != nil {
 		sentry.Debug(c).Err(err).Msg("tracing quarterdeck error in tenant")
 		api.ReplyQuarterdeckError(c, err)
 		return
 	}
+
+	// Update project stats in the background
+	s.tasks.QueueContext(middleware.TaskContext(c), tasks.TaskFunc(func(ctx context.Context) error {
+		return s.UpdateProjectStats(ctx, key.ProjectID)
+	}), tasks.WithError(fmt.Errorf("could not update stats for project %s", key.ProjectID.String())))
 
 	c.Status(http.StatusNoContent)
 }

--- a/pkg/tenant/projects_test.go
+++ b/pkg/tenant/projects_test.go
@@ -259,7 +259,7 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 	}
 
 	// Quarterdeck server mock expects authentication and returns 200 OK
-	suite.quarterdeck.OnProjects("", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(&qd.Project{}), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsCreate(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(&qd.Project{}), mock.RequireAuth())
 
 	// Set the initial claims fixture
 	claims := &tokens.Claims{
@@ -323,12 +323,12 @@ func (suite *tenantTestSuite) TestTenantProjectCreate() {
 	require.NotEmpty(project.Modified, "expected non-zero modified time to be populated")
 
 	// Should return an error if the Quarterdeck returns an error
-	suite.quarterdeck.OnProjects("", mock.UseError(http.StatusInternalServerError, "could not create project"), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsCreate(mock.UseError(http.StatusInternalServerError, "could not create project"), mock.RequireAuth())
 	_, err = suite.client.TenantProjectCreate(ctx, tenantID.String(), req)
 	suite.requireError(err, http.StatusInternalServerError, "could not create project", "expected error when quarterdeck returns an error")
 
 	// Quarterdeck mock should have been called
-	require.Equal(2, suite.quarterdeck.ProjectsCount(""), "expected quarterdeck mock to be called")
+	require.Equal(2, suite.quarterdeck.ProjectsCreateCount(), "expected quarterdeck mock to be called")
 }
 
 func (suite *tenantTestSuite) TestTenantProjectPatch() {
@@ -665,7 +665,7 @@ func (suite *tenantTestSuite) TestProjectCreate() {
 	}
 
 	// Quarterdeck server mock expects authentication and returns 200 OK
-	suite.quarterdeck.OnProjects("", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(&qd.Project{}), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsCreate(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(&qd.Project{}), mock.RequireAuth())
 
 	// Set the initial claims fixture.
 	claims := &tokens.Claims{
@@ -725,12 +725,12 @@ func (suite *tenantTestSuite) TestProjectCreate() {
 	require.NotEmpty(project.Modified, "project modified should not be empty")
 
 	// Should return an error if the Quarterdeck returns an error
-	suite.quarterdeck.OnProjects("", mock.UseError(http.StatusInternalServerError, "could not create project"), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsCreate(mock.UseError(http.StatusInternalServerError, "could not create project"), mock.RequireAuth())
 	_, err = suite.client.ProjectCreate(ctx, req)
 	suite.requireError(err, http.StatusInternalServerError, "could not create project", "expected error when quarterdeck returns an error")
 
 	// Quarterdeck mock should have been called
-	require.Equal(2, suite.quarterdeck.ProjectsCount(""), "expected quarterdeck mock to be called")
+	require.Equal(2, suite.quarterdeck.ProjectsCreateCount(), "expected quarterdeck mock to be called")
 }
 
 func (suite *tenantTestSuite) TestProjectDetail() {
@@ -1303,14 +1303,14 @@ func (suite *tenantTestSuite) TestUpdateProjectStats() {
 	}
 
 	// Initial quarterdeck mock should return the project info
-	suite.quarterdeck.OnProjects(projectID.String(), mock.UseStatus(http.StatusOK), mock.UseJSONFixture(qdProject), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsDetail(projectID.String(), mock.UseStatus(http.StatusOK), mock.UseJSONFixture(qdProject), mock.RequireAuth())
 
 	// Project access should return the access token
 	login := &qd.LoginReply{
 		AccessToken:  "access",
 		RefreshToken: "refresh",
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(login), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(login), mock.RequireAuth())
 
 	// Initial ensign mock should return the project info
 	suite.ensign.OnInfo = func(ctx context.Context, in *en.InfoRequest) (*en.ProjectInfo, error) {
@@ -1353,7 +1353,7 @@ func (suite *tenantTestSuite) TestUpdateProjectStats() {
 		return enProject, nil
 	}
 	expectedTopics = 3
-	suite.quarterdeck.OnProjects(projectID.String(), mock.UseError(http.StatusUnauthorized, "invalid claims"), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsDetail(projectID.String(), mock.UseError(http.StatusUnauthorized, "invalid claims"), mock.RequireAuth())
 	expectedAPIKeys = 0
 	err = suite.srv.UpdateProjectStats(ctx, projectID)
 	require.ErrorContains(err, statusMessage(http.StatusUnauthorized, "invalid claims"), "expected an error if only the quarterdeck rpc fails")

--- a/pkg/tenant/tenants.go
+++ b/pkg/tenant/tenants.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/oklog/ulid/v2"
-	qd "github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/middleware"
 	"github.com/rotationalio/ensign/pkg/tenant/api/v1"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
@@ -405,30 +404,7 @@ func (s *Server) TenantStats(c *gin.Context) {
 			return
 		}
 		totalTopics += len(topics)
-
-		// API keys are stored in Quarterdeck
-		req := &qd.APIPageQuery{
-			ProjectID: project.ID.String(),
-			PageSize:  100,
-		}
-
-		// We will always retrieve at least one page; it's possible but unlikely for a
-		// project to have more than 100 API keys.
-	keysLoop:
-		for {
-			var page *qd.APIKeyList
-			if page, err = s.quarterdeck.APIKeyList(ctx, req); err != nil {
-				sentry.Debug(c).Err(err).Msg("tracing quarterdeck error in tenant")
-				api.ReplyQuarterdeckError(c, err)
-				return
-			}
-			totalKeys += len(page.APIKeys)
-
-			if page.NextPageToken == "" {
-				break keysLoop
-			}
-			req.NextPageToken = page.NextPageToken
-		}
+		totalKeys += int(project.APIKeys)
 	}
 
 	// Build the standardized stats response for the frontend

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -268,7 +268,7 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 	}
 
 	// Connect to Quarterdeck mock.
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply), mock.RequireAuth())
 
 	detail := &qd.Project{
 		OrgID:        project.OrgID,
@@ -277,7 +277,7 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 		RevokedCount: 1,
 	}
 
-	suite.quarterdeck.OnProjects(project.ID.String(), mock.UseStatus(http.StatusOK), mock.UseJSONFixture(detail), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsDetail(project.ID.String(), mock.UseStatus(http.StatusOK), mock.UseJSONFixture(detail), mock.RequireAuth())
 
 	enTopic := &sdk.Topic{
 		ProjectId: project.ID[:],
@@ -376,12 +376,12 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 	require.Equal(4, trtl.Calls[trtlmock.PutRPC], "expected Put to be called 4 times, 3 for the new topic and the indexes, and 1 for the project update")
 
 	// Should return an error if Quarterdeck returns an error.
-	suite.quarterdeck.OnProjects("access", mock.UseError(http.StatusBadRequest, "missing field project_id"), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsAccess(mock.UseError(http.StatusBadRequest, "missing field project_id"), mock.RequireAuth())
 	_, err = suite.client.ProjectTopicCreate(ctx, projectID, req)
 	suite.requireError(err, http.StatusBadRequest, "missing field project_id", "expected error when Quarterdeck returns an error")
 
 	// Should return an error if Ensign returns an error.
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply), mock.RequireAuth())
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply), mock.RequireAuth())
 	suite.ensign.OnCreateTopic = func(ctx context.Context, t *sdk.Topic) (*sdk.Topic, error) {
 		return &sdk.Topic{}, status.Error(codes.Internal, "could not create topic")
 	}
@@ -792,7 +792,7 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 		AccessToken:  "access",
 		RefreshToken: "refresh",
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
 
 	// Configure Ensign to return a success response on DeleteTopic requests.
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
@@ -911,12 +911,12 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 			return nil, status.Errorf(codes.NotFound, "namespace %q not found", gr.Namespace)
 		}
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseError(http.StatusInternalServerError, "could not get one time credentials"))
+	suite.quarterdeck.OnProjectsAccess(mock.UseError(http.StatusInternalServerError, "could not get one time credentials"))
 	_, err = suite.client.TopicUpdate(ctx, req)
 	suite.requireError(err, http.StatusInternalServerError, "could not get one time credentials", "expected error when Quarterdeck returns an error")
 
 	// Should return not found if Ensign returns not found.
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
 		return nil, status.Error(codes.NotFound, "could not archive topic")
 	}
@@ -985,7 +985,7 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 		AccessToken:  "access",
 		RefreshToken: "refresh",
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
 
 	// Configure Ensign to return a success response on DeleteTopic requests.
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
@@ -1100,12 +1100,12 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 			return nil, status.Errorf(codes.NotFound, "namespace %q not found", gr.Namespace)
 		}
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseError(http.StatusInternalServerError, "could not get one time credentials"))
+	suite.quarterdeck.OnProjectsAccess(mock.UseError(http.StatusInternalServerError, "could not get one time credentials"))
 	_, err = suite.client.TopicDelete(ctx, req)
 	suite.requireError(err, http.StatusInternalServerError, "could not get one time credentials", "expected error when Quarterdeck returns an error")
 
 	// Should return not found if Ensign returns not found.
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+	suite.quarterdeck.OnProjectsAccess(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
 		return nil, status.Error(codes.NotFound, "could not delete topic")
 	}


### PR DESCRIPTION
### Scope of changes

This fixes an issue where Tenant was being rate limited by Quarterdeck. We no longer need to call Quarterdeck on every tenant stats call, since the API key count is being updated asynchronously.

Fixes SC-19371

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Tenant stats endpoint should no longer be returning rate limit errors to the user.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

