### PR TITLE
Integrate quarterdeck token cache

### DIFF
--- a/pkg/quarterdeck/tokens/cache.go
+++ b/pkg/quarterdeck/tokens/cache.go
@@ -138,6 +138,14 @@ func (c *Cache) Remove(userID, projectID ulid.ULID) {
 	}
 }
 
+// Clear the entire cache.
+func (c *Cache) Clear() {
+	c.Lock()
+	defer c.Unlock()
+	c.items.Init()
+	c.index = make(map[string]*list.Element, 0)
+}
+
 // Return the current size of the cache for profiling or testing purposes.
 func (c *Cache) Size() int {
 	c.RLock()

--- a/pkg/tenant/apikeys.go
+++ b/pkg/tenant/apikeys.go
@@ -148,6 +148,12 @@ func (s *Server) ProjectAPIKeyCreate(c *gin.Context) {
 		return
 	}
 
+	// Get the user ID from the context
+	var userID ulid.ULID
+	if userID = userIDFromContext(c); ulids.IsZero(userID) {
+		return
+	}
+
 	// Parse the params from the POST request
 	params := &api.APIKey{}
 	if err = c.BindJSON(params); err != nil {
@@ -228,7 +234,7 @@ func (s *Server) ProjectAPIKeyCreate(c *gin.Context) {
 
 	// Update project stats in the background
 	s.tasks.QueueContext(middleware.TaskContext(c), tasks.TaskFunc(func(ctx context.Context) error {
-		return s.UpdateProjectStats(ctx, key.ProjectID)
+		return s.UpdateProjectStats(ctx, userID, key.ProjectID)
 	}), tasks.WithError(fmt.Errorf("could not update stats for project %s", key.ProjectID.String())))
 
 	c.JSON(http.StatusCreated, out)

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -242,6 +242,14 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 		Modified: time.Now(),
 	}
 
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		OrgID:       "01GNA91N6WMCWNG9MVSK47ZS88",
+		Permissions: []string{"create:nothing"},
+	}
+
 	key, err := project.Key()
 	require.NoError(err, "could not create project key")
 
@@ -263,8 +271,11 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 		}
 	}
 
+	// Create the Quarterdeck reply fixture
+	token, err := suite.auth.CreateAccessToken(claims)
+	require.NoError(err, "could not create access token")
 	reply := &qd.LoginReply{
-		AccessToken: "token",
+		AccessToken: token,
 	}
 
 	// Connect to Quarterdeck mock.
@@ -306,14 +317,6 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 	// Call OnPut method and return a PutReply.
 	trtl.OnPut = func(ctx context.Context, pr *pb.PutRequest) (*pb.PutReply, error) {
 		return &pb.PutReply{}, nil
-	}
-
-	// Set the initial claims fixture
-	claims := &tokens.Claims{
-		Name:        "Leopold Wentzel",
-		Email:       "leopold.wentzel@gmail.com",
-		OrgID:       "01GNA91N6WMCWNG9MVSK47ZS88",
-		Permissions: []string{"create:nothing"},
 	}
 
 	// Endpoint must be authenticated
@@ -362,6 +365,8 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 		Name: enTopic.Name,
 	}
 
+	// Successfully create a topic.
+	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply), mock.RequireAuth())
 	topic, err := suite.client.ProjectTopicCreate(ctx, projectID, req)
 	require.NoError(err, "could not add topic")
 	require.NotEmpty(topic.ID, "expected non-zero ulid to be populated")
@@ -372,11 +377,21 @@ func (suite *tenantTestSuite) TestProjectTopicCreate() {
 	// Ensure project stats update task finishes.
 	suite.StopTasks()
 
+	// Create another topic with this user which exercises the cache.
+	suite.ResetTasks()
+	topic, err = suite.client.ProjectTopicCreate(ctx, projectID, req)
+	require.NoError(err, "could not add topic")
+	suite.StopTasks()
+
 	// Ensure that the topic was updated and the project stats were updated.
-	require.Equal(4, trtl.Calls[trtlmock.PutRPC], "expected Put to be called 4 times, 3 for the new topic and the indexes, and 1 for the project update")
+	require.Equal(8, trtl.Calls[trtlmock.PutRPC], "expected Put to be called 8 times, 6 for the new topic and the indexes, and 2 for the project updates")
+
+	// Quarterdeck should be called once, the cache should be used for subsequent calls.
+	require.Equal(1, suite.quarterdeck.ProjectsCount("access"), "expected only 1 call to Quarterdeck for project access")
 
 	// Should return an error if Quarterdeck returns an error.
 	suite.quarterdeck.OnProjects("access", mock.UseError(http.StatusBadRequest, "missing field project_id"), mock.RequireAuth())
+	suite.srv.ResetCache()
 	_, err = suite.client.ProjectTopicCreate(ctx, projectID, req)
 	suite.requireError(err, http.StatusBadRequest, "missing field project_id", "expected error when Quarterdeck returns an error")
 
@@ -787,12 +802,20 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 		return &pb.PutReply{}, nil
 	}
 
-	// Configure Quarterdeck to return a success response on ProjectAccess requests.
-	auth := &qd.LoginReply{
-		AccessToken:  "access",
-		RefreshToken: "refresh",
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"write:nothing"},
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+
+	// Create the Quarterdeck reply fixture
+	token, err := suite.auth.CreateAccessToken(claims)
+	require.NoError(err, "could not create access token")
+	reply := &qd.LoginReply{
+		AccessToken: token,
+	}
+	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply))
 
 	// Configure Ensign to return a success response on DeleteTopic requests.
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
@@ -800,13 +823,6 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 			Id:    topic.ID.String(),
 			State: sdk.TopicTombstone_READONLY,
 		}, nil
-	}
-
-	// Set the initial claims fixture
-	claims := &tokens.Claims{
-		Name:        "Leopold Wentzel",
-		Email:       "leopold.wentzel@gmail.com",
-		Permissions: []string{"write:nothing"},
 	}
 
 	// Endpoint must be authenticated
@@ -885,6 +901,14 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 	_, err = suite.client.TopicUpdate(ctx, req)
 	suite.requireError(err, http.StatusNotImplemented, "archiving a topic is not supported")
 
+	// Make another topic update request to exercise the cache.
+	req.Name = "AnotherTopicName"
+	_, err = suite.client.TopicUpdate(ctx, req)
+	suite.requireError(err, http.StatusNotImplemented, "archiving a topic is not supported")
+
+	// Quarterdeck should only be called once, subsequent calls should use the cache.
+	require.Equal(1, suite.quarterdeck.ProjectsCount("access"), "expected only one call to Quarterdeck for project access")
+
 	// Should return an error if the topic ID is parsed but not found.
 	trtl.OnGet = func(ctx context.Context, in *pb.GetRequest) (*pb.GetReply, error) {
 		if len(in.Key) == 0 || in.Namespace == db.OrganizationNamespace {
@@ -911,12 +935,13 @@ func (suite *tenantTestSuite) TestTopicUpdate() {
 			return nil, status.Errorf(codes.NotFound, "namespace %q not found", gr.Namespace)
 		}
 	}
+	suite.srv.ResetCache()
 	suite.quarterdeck.OnProjects("access", mock.UseError(http.StatusInternalServerError, "could not get one time credentials"))
 	_, err = suite.client.TopicUpdate(ctx, req)
 	suite.requireError(err, http.StatusInternalServerError, "could not get one time credentials", "expected error when Quarterdeck returns an error")
 
 	// Should return not found if Ensign returns not found.
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply))
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
 		return nil, status.Error(codes.NotFound, "could not archive topic")
 	}
@@ -980,12 +1005,20 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 		return &pb.DeleteReply{}, nil
 	}
 
-	// Configure Quarterdeck to return a success response on ProjectAccess requests.
-	auth := &qd.LoginReply{
-		AccessToken:  "access",
-		RefreshToken: "refresh",
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"delete:nothing"},
 	}
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+
+	// Create the Quarterdeck reply fixture
+	accessToken, err := suite.auth.CreateAccessToken(claims)
+	require.NoError(err, "could not create access token")
+	qdReply := &qd.LoginReply{
+		AccessToken: accessToken,
+	}
+	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(qdReply))
 
 	// Configure Ensign to return a success response on DeleteTopic requests.
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
@@ -993,13 +1026,6 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 			Id:    topic.ID.String(),
 			State: sdk.TopicTombstone_DELETING,
 		}, nil
-	}
-
-	// Set the initial claims fixture
-	claims := &tokens.Claims{
-		Name:        "Leopold Wentzel",
-		Email:       "leopold.wentzel@gmail.com",
-		Permissions: []string{"delete:nothing"},
 	}
 
 	// Endpoint must be authenticated
@@ -1075,6 +1101,13 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 	_, err = suite.client.TopicDelete(ctx, req)
 	suite.requireError(err, http.StatusNotImplemented, "deleting a topic is not supported")
 
+	// Make a second call to the delete endpoint to exercise the cache.
+	_, err = suite.client.TopicDelete(ctx, req)
+	suite.requireError(err, http.StatusNotImplemented, "deleting a topic is not supported")
+
+	// Quarterdeck should only be called once, subsequent calls should use the cache.
+	require.Equal(1, suite.quarterdeck.ProjectsCount("access"), "expected only one call to Quarterdeck for project access")
+
 	// Should return an error if the topic ID is parsed but not found.
 	trtl.OnGet = func(ctx context.Context, in *pb.GetRequest) (*pb.GetReply, error) {
 		if len(in.Key) == 0 || in.Namespace == db.OrganizationNamespace {
@@ -1100,12 +1133,13 @@ func (suite *tenantTestSuite) TestTopicDelete() {
 			return nil, status.Errorf(codes.NotFound, "namespace %q not found", gr.Namespace)
 		}
 	}
+	suite.srv.ResetCache()
 	suite.quarterdeck.OnProjects("access", mock.UseError(http.StatusInternalServerError, "could not get one time credentials"))
 	_, err = suite.client.TopicDelete(ctx, req)
 	suite.requireError(err, http.StatusInternalServerError, "could not get one time credentials", "expected error when Quarterdeck returns an error")
 
 	// Should return not found if Ensign returns not found.
-	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(auth))
+	suite.quarterdeck.OnProjects("access", mock.UseStatus(http.StatusOK), mock.UseJSONFixture(qdReply))
 	suite.ensign.OnDeleteTopic = func(ctx context.Context, req *sdk.TopicMod) (*sdk.TopicTombstone, error) {
 		return nil, status.Error(codes.NotFound, "could not delete topic")
 	}


### PR DESCRIPTION
### Scope of changes

This finalizes the user session token caching work by integrating the cache into Tenant.

Fixes SC-19349

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

- Add the token cache to the Quarterdeck client or Tenant server object
- Ensure that the "project access" endpoints are using the cache
- Ensure that the tests still run

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

