### PR TITLE
Fix Quarterdeck Refresh Bug

### DIFF
--- a/pkg/quarterdeck/apikeys.go
+++ b/pkg/quarterdeck/apikeys.go
@@ -290,6 +290,7 @@ func (s *Server) APIKeyDetail(c *gin.Context) {
 	}
 
 	// Ensure that the orgID on the claims matches the orgID on the APIKey
+	// TODO: this should be in the RetrieveAPIKey method
 	if claims.OrgID != model.OrgID.String() {
 		sentry.Warn(c).Msg("attempt to fetch key from different organization")
 		c.JSON(http.StatusNotFound, api.ErrorResponse("api key not found"))

--- a/pkg/quarterdeck/db/models/errors.go
+++ b/pkg/quarterdeck/db/models/errors.go
@@ -32,6 +32,7 @@ var (
 	ErrInvalidPermission   = errors.New("invalid permission specified for apikey")
 	ErrModifyPermissions   = errors.New("cannot modify permissions on an existing APIKey object")
 	ErrInvalidToken        = errors.New("token is invalid or expired")
+	ErrSubjectCollision    = errors.New("subject was identified as both user and apikey")
 	ErrMissingPageSize     = errors.New("cannot list database without a page size")
 	ErrInvalidCursor       = errors.New("could not compute the next page of results")
 	ErrDuplicate           = errors.New("unique constraint violated on model")

--- a/pkg/quarterdeck/db/models/subject.go
+++ b/pkg/quarterdeck/db/models/subject.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/db"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
+)
+
+type SubjectType uint8
+
+const (
+	UnknownSubject SubjectType = iota
+	UserSubject
+	APIKeySubject
+)
+
+const identifySubjectSQL = `WITH user_exists AS (
+	SELECT EXISTS(
+		SELECT user_id FROM organization_users WHERE organization_id=:orgID AND user_id=:subjectID
+	)
+), apikey_exists AS (
+	SELECT EXISTS(
+		SELECT id FROM api_keys WHERE organization_id=:orgID AND id=:subjectID
+	)
+) SELECT * FROM user_exists, apikey_exists;`
+
+// IdentifySubject is a helper tool to check the database to determine if the specified
+// subject from authentication claims refers to a user or to an apikey. This method
+// relies on the fact that the database IDs are ULIDs, meaning that it is highly
+// unlikely that a user id and an apikey id are the same (technically possible, but with
+// the same collision probability as a UUID). This is made further unlikely by requiring
+// an organization ID is specified to return the subject type.
+func IdentifySubject(ctx context.Context, subjectID, orgID any) (_ SubjectType, err error) {
+	var sub ulid.ULID
+	if sub, err = ulids.Parse(subjectID); err != nil {
+		return UnknownSubject, err
+	}
+
+	var org ulid.ULID
+	if org, err = ulids.Parse(orgID); err != nil {
+		return UnknownSubject, err
+	}
+
+	if ulids.IsZero(sub) || ulids.IsZero(org) {
+		return UnknownSubject, ErrNotFound
+	}
+
+	var tx *sql.Tx
+	if tx, err = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true}); err != nil {
+		return UnknownSubject, err
+	}
+	defer tx.Rollback()
+
+	var isUser, isAPIKey bool
+	if err = tx.QueryRow(identifySubjectSQL, sql.Named("subjectID", sub), sql.Named("orgID", org)).Scan(&isUser, &isAPIKey); err != nil {
+		return UnknownSubject, err
+	}
+
+	switch {
+	case isUser && !isAPIKey:
+		return UserSubject, nil
+	case isAPIKey && !isUser:
+		return APIKeySubject, nil
+	case isUser && isAPIKey:
+		return UnknownSubject, ErrSubjectCollision
+	default:
+		return UnknownSubject, ErrNotFound
+	}
+}

--- a/pkg/quarterdeck/db/models/subject_test.go
+++ b/pkg/quarterdeck/db/models/subject_test.go
@@ -1,0 +1,39 @@
+package models_test
+
+import (
+	"context"
+
+	"github.com/oklog/ulid/v2"
+	. "github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
+)
+
+func (m *modelTestSuite) TestIdentifySubject() {
+	require := m.Require()
+
+	testCases := []struct {
+		subID    string
+		orgID    string
+		expected SubjectType
+		err      error
+	}{
+		{"01GQFQ4475V3BZDMSXFV5DK6XX", "01GQFQ14HXF2VC7C1HJECS60XX", UserSubject, nil},
+		{"01GZ458FBCST1AC1M4PY4X7QZZ", "01GKHJRF01YXHZ51YMMKV3RCMK", APIKeySubject, nil},
+		{"01GZ458FBCST1AC1M4PY4X7QZZ", "01GQFQ14HXF2VC7C1HJECS60XX", UnknownSubject, ErrNotFound},
+		{"01GQFQ4475V3BZDMSXFV5DK6XX", "01GQZAC80RAZ1XQJKRZJ2R4KNJ", UnknownSubject, ErrNotFound},
+		{"01H6PZZ9WMEAWR3YZDDPFXWKBZ", "01GQZAC80RAZ1XQJKRZJ2R4KNJ", UnknownSubject, ErrNotFound},
+		{"", "01GQFQ14HXF2VC7C1HJECS60XX", UnknownSubject, ErrNotFound},
+		{"01GZ458FBCST1AC1M4PY4X7QZZ", "", UnknownSubject, ErrNotFound},
+		{"notaulid", "01GQFQ14HXF2VC7C1HJECS60XX", UnknownSubject, ulid.ErrDataSize},
+		{"01GZ458FBCST1AC1M4PY4X7QZZ", "notaulid", UnknownSubject, ulid.ErrDataSize},
+	}
+
+	for i, tc := range testCases {
+		actual, err := IdentifySubject(context.Background(), tc.subID, tc.orgID)
+		if tc.err != nil {
+			require.ErrorIs(err, tc.err, "expected error for test case %d", i)
+		} else {
+			require.NoError(err, "expected no error for test case %d", i)
+			require.Equal(tc.expected, actual, "unexpected subject type returned")
+		}
+	}
+}

--- a/pkg/quarterdeck/tokens/jwks_test.go
+++ b/pkg/quarterdeck/tokens/jwks_test.go
@@ -29,10 +29,14 @@ func (s *TokenTestSuite) TestJWKSValidator() {
 
 	claims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject: "1234",
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	atks, rtks, err := tm.CreateTokenPair(claims)
@@ -97,10 +101,14 @@ func (s *TokenTestSuite) TestCachedJWKSValidator() {
 
 	claims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject: "1234",
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	atks, _, err := tm.CreateTokenPair(claims)

--- a/pkg/quarterdeck/tokens/tokens.go
+++ b/pkg/quarterdeck/tokens/tokens.go
@@ -218,7 +218,8 @@ func (tm *TokenManager) CreateRefreshToken(accessToken *jwt.Token) (refreshToken
 			NotBefore: jwt.NewNumericDate(accessClaims.ExpiresAt.Add(tm.conf.RefreshOverlap)),
 			ExpiresAt: jwt.NewNumericDate(accessClaims.IssuedAt.Add(tm.conf.RefreshDuration)),
 		},
-		OrgID: accessClaims.OrgID,
+		OrgID:     accessClaims.OrgID,
+		ProjectID: accessClaims.ProjectID,
 	}
 	return tm.CreateToken(claims), nil
 }

--- a/pkg/quarterdeck/tokens/tokens.go
+++ b/pkg/quarterdeck/tokens/tokens.go
@@ -218,6 +218,7 @@ func (tm *TokenManager) CreateRefreshToken(accessToken *jwt.Token) (refreshToken
 			NotBefore: jwt.NewNumericDate(accessClaims.ExpiresAt.Add(tm.conf.RefreshOverlap)),
 			ExpiresAt: jwt.NewNumericDate(accessClaims.IssuedAt.Add(tm.conf.RefreshDuration)),
 		},
+		OrgID: accessClaims.OrgID,
 	}
 	return tm.CreateToken(claims), nil
 }

--- a/pkg/quarterdeck/tokens/tokens_test.go
+++ b/pkg/quarterdeck/tokens/tokens_test.go
@@ -60,10 +60,14 @@ func (s *TokenTestSuite) TestCreateTokenPair() {
 
 	claims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject: "1234",
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
 		},
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	atks, rtks, err := tm.CreateTokenPair(claims)
@@ -94,8 +98,15 @@ func (s *TokenTestSuite) TestTokenManager() {
 
 	// Create an access token from simple claims
 	creds := &tokens.Claims{
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
+		},
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	accessToken, err := tm.CreateAccessToken(creds)
@@ -113,8 +124,13 @@ func (s *TokenTestSuite) TestTokenManager() {
 	require.True(ac.IssuedAt.Before(now))
 	require.True(ac.NotBefore.Before(now))
 	require.True(ac.ExpiresAt.After(now))
-	require.Equal(creds.Email, ac.Email)
+	require.Equal(creds.Subject, ac.Subject)
 	require.Equal(creds.Name, ac.Name)
+	require.Equal(creds.Email, ac.Email)
+	require.Equal(creds.Picture, ac.Picture)
+	require.Equal(creds.OrgID, ac.OrgID)
+	require.Equal(creds.ProjectID, ac.ProjectID)
+	require.Equal(creds.Permissions, ac.Permissions)
 
 	// Create a refresh token from the access token
 	refreshToken, err := tm.CreateRefreshToken(accessToken)
@@ -122,19 +138,21 @@ func (s *TokenTestSuite) TestTokenManager() {
 	require.IsType(&tokens.Claims{}, refreshToken.Claims)
 
 	// Check refresh token claims
-	// Check access token claims
 	rc := refreshToken.Claims.(*tokens.Claims)
 	require.Equal(ac.ID, rc.ID, "access and refresh tokens must have same jid")
 	require.Equal(jwt.ClaimStrings{"http://localhost:3000", "http://localhost:3001/v1/refresh"}, rc.Audience)
 	require.NotEqual(ac.Audience, rc.Audience, "identical access token and refresh token audience")
 	require.Equal(ac.Issuer, rc.Issuer)
-	require.Equal(ac.Subject, rc.Subject)
-	require.Equal(ac.OrgID, rc.OrgID)
 	require.True(rc.IssuedAt.Equal(ac.IssuedAt.Time))
 	require.True(rc.NotBefore.After(now))
 	require.True(rc.ExpiresAt.After(rc.NotBefore.Time))
-	require.Empty(rc.Email)
+	require.Equal(ac.Subject, rc.Subject)
 	require.Empty(rc.Name)
+	require.Empty(rc.Email)
+	require.Empty(rc.Picture)
+	require.Equal(ac.OrgID, rc.OrgID)
+	require.Equal(ac.ProjectID, rc.ProjectID)
+	require.Empty(rc.Permissions)
 
 	// Verify relative nbf and exp claims of access and refresh tokens
 	require.True(ac.IssuedAt.Equal(rc.IssuedAt.Time), "access and refresh tokens do not have same iss timestamp")
@@ -167,8 +185,15 @@ func (s *TokenTestSuite) TestValidTokens() {
 
 	// Default creds
 	creds := &tokens.Claims{
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
+		},
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	// TODO: add validation steps and test
@@ -187,13 +212,18 @@ func (s *TokenTestSuite) TestInvalidTokens() {
 	claims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			ID:        uuid.NewString(),                               // id not validated
+			Subject:   "01H6PGFB4T34D4WWEXQMAGJNMK",                   // correct subject
 			Audience:  jwt.ClaimStrings{"http://foo.example.com"},     // wrong audience
 			IssuedAt:  jwt.NewNumericDate(now.Add(-1 * time.Hour)),    // iat not validated
 			NotBefore: jwt.NewNumericDate(now.Add(15 * time.Minute)),  // nbf is validated and is after now
 			ExpiresAt: jwt.NewNumericDate(now.Add(-30 * time.Minute)), // exp is validated and is before now
 		},
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	// Test validation signed with wrong kid
@@ -276,8 +306,15 @@ func (s *TokenTestSuite) TestKeyRotation() {
 
 	// Create a valid token with the "old token manager"
 	token, err := oldTM.CreateAccessToken(&tokens.Claims{
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
+		},
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	})
 	require.NoError(err)
 
@@ -305,8 +342,15 @@ func (s *TokenTestSuite) TestParseExpiredToken() {
 
 	// Default creds
 	creds := &tokens.Claims{
-		Email: "kate@rotational.io",
-		Name:  "Kate Holland",
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject: "01H6PGFB4T34D4WWEXQMAGJNMK",
+		},
+		Name:        "Kate Holland",
+		Email:       "kate@example.co",
+		Picture:     "https://www.gravatar.com/avatar/80ebb3b0dae3f550de72021bdcf45d00",
+		OrgID:       "01H6PGFG71N0AFEVTK3NJB71T9",
+		ProjectID:   "01H6PGFTK2X53RGG2KMSGR2M61",
+		Permissions: []string{"read:foo", "edit:foo", "delete:foo"},
 	}
 
 	accessToken, err := tm.CreateAccessToken(creds)

--- a/pkg/quarterdeck/tokens/tokens_test.go
+++ b/pkg/quarterdeck/tokens/tokens_test.go
@@ -129,6 +129,7 @@ func (s *TokenTestSuite) TestTokenManager() {
 	require.NotEqual(ac.Audience, rc.Audience, "identical access token and refresh token audience")
 	require.Equal(ac.Issuer, rc.Issuer)
 	require.Equal(ac.Subject, rc.Subject)
+	require.Equal(ac.OrgID, rc.OrgID)
 	require.True(rc.IssuedAt.Equal(ac.IssuedAt.Time))
 	require.True(rc.NotBefore.After(now))
 	require.True(rc.ExpiresAt.After(rc.NotBefore.Time))

--- a/pkg/utils/sentry/logger.go
+++ b/pkg/utils/sentry/logger.go
@@ -130,6 +130,12 @@ func (e *Event) Int(key string, value int) *Event {
 	return e
 }
 
+func (e *Event) Uint8(key string, value uint8) *Event {
+	e.extra[key] = value
+	e.zero = e.zero.Uint8(key, value)
+	return e
+}
+
 func (e *Event) ULID(key string, value ulid.ULID) *Event {
 	s := value.String()
 	e.extra[key] = s


### PR DESCRIPTION
### Scope of changes

Fixes the Quarterdeck refresh bug that was caught in Sentry: could not retrieve user from database. It appears that what was happening was that the orgID was not on the refresh token claims, so the refresh ended up using an empty orgID for refresh so no token was returned. It is actually unclear if this will fix the issue, but instead of a 500 error being returned, a 400 error will be returned. 

Fixes SC-18236

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Do we need to look deeper into PyEnsign to see if the problem is there? Should the default orgID have been returned? Is the issue that the subject of the access token is not correct?

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [x] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

