### PR TITLE
Initial tenant query endpoint

### DIFF
--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -53,6 +53,8 @@ type TenantClient interface {
 	ProjectTopicList(ctx context.Context, id string, in *PageQuery) (*ProjectTopicPage, error)
 	ProjectTopicCreate(ctx context.Context, id string, in *Topic) (*Topic, error)
 
+	ProjectQuery(ctx context.Context, in *ProjectQueryRequest) (*ProjectQueryResponse, error)
+
 	TopicList(context.Context, *PageQuery) (*TopicPage, error)
 	TopicDetail(ctx context.Context, id string) (*Topic, error)
 	TopicStats(ctx context.Context, id string) ([]*StatValue, error)
@@ -277,6 +279,25 @@ type ProjectTopicPage struct {
 	ProjectID     string   `json:"project_id"`
 	Topics        []*Topic `json:"topics"`
 	NextPageToken string   `json:"next_page_token,omitempty"`
+}
+
+type ProjectQueryRequest struct {
+	ProjectID string `json:"project_id"`
+	Query     string `json:"query"`
+}
+
+type ProjectQueryResponse struct {
+	Results []*QueryResult `json:"results"`
+	Error   string         `json:"error,omitempty"`
+}
+
+type QueryResult struct {
+	Metadata        map[string]string `json:"metadata"`
+	Mimetype        string            `json:"mimetype"`
+	Version         string            `json:"version"`
+	IsBase64Encoded bool              `json:"is_base64_encoded"`
+	Data            string            `json:"data"`
+	Created         string            `json:"created"`
 }
 
 type Topic struct {

--- a/pkg/tenant/api/v1/client.go
+++ b/pkg/tenant/api/v1/client.go
@@ -719,6 +719,27 @@ func (s *APIv1) ProjectTopicCreate(ctx context.Context, id string, in *Topic) (o
 	return out, err
 }
 
+func (s *APIv1) ProjectQuery(ctx context.Context, in *ProjectQueryRequest) (out *ProjectQueryResponse, err error) {
+	if in.ProjectID == "" {
+		return nil, ErrProjectIDRequired
+	}
+
+	path := fmt.Sprintf("/v1/projects/%s/query", in.ProjectID)
+
+	// Make the HTTP request
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, path, in, nil); err != nil {
+		return nil, err
+	}
+
+	out = &ProjectQueryResponse{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 func (s *APIv1) TopicList(ctx context.Context, in *PageQuery) (out *TopicPage, err error) {
 	var params url.Values
 	if params, err = query.Values(in); err != nil {

--- a/pkg/tenant/api/v1/client_test.go
+++ b/pkg/tenant/api/v1/client_test.go
@@ -1172,6 +1172,49 @@ func TestProjectTopicCreate(t *testing.T) {
 	require.Equal(t, fixture, out, "unexpected response returned")
 }
 
+func TestProjectQuery(t *testing.T) {
+	fixture := &api.ProjectQueryResponse{
+		Results: []*api.QueryResult{
+			{
+				Metadata: map[string]string{
+					"key": "value",
+				},
+				Mimetype: "application/json",
+				Version:  "Document v1.0.1",
+				Data:     "{\"foo\": \"bar\"}",
+				Created:  time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	// Create a test server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/projects/project001/query", r.URL.Path)
+
+		in := &api.ProjectQueryRequest{}
+		err := json.NewDecoder(r.Body).Decode(in)
+		require.NoError(t, err, "could not decode request")
+
+		w.Header().Add("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
+	}))
+	defer ts.Close()
+
+	// Create a client to execute requests against the test server
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create api client")
+
+	req := &api.ProjectQueryRequest{
+		ProjectID: "project001",
+		Query:     "SELECT * FROM topic001 LIMIT 10",
+	}
+	out, err := client.ProjectQuery(context.Background(), req)
+	require.NoError(t, err, "could not execute api request")
+	require.Equal(t, fixture, out, "unexpected response returned")
+}
+
 func TestTopicList(t *testing.T) {
 	fixture := &api.TopicPage{
 		Topics: []*api.Topic{

--- a/pkg/tenant/api/v1/errors.go
+++ b/pkg/tenant/api/v1/errors.go
@@ -22,6 +22,8 @@ var (
 	ErrTopicIDRequired        = errors.New("topic id is required for this endpoint")
 	ErrTokenRequired          = errors.New("token is required for this endpoint")
 	ErrInvalidTenantField     = errors.New("invalid tenant field")
+	ErrMissingQueryField      = errors.New("missing query field")
+	ErrQueryTooLong           = errors.New("query string is too long, please use the SDKs for complex queries")
 	ErrInvalidUserClaims      = errors.New("user claims invalid or unavailable")
 	ErrUnparsable             = errors.New("could not parse request")
 )

--- a/pkg/tenant/fixtures.go
+++ b/pkg/tenant/fixtures.go
@@ -1,0 +1,150 @@
+package tenant
+
+import (
+	api "github.com/rotationalio/go-ensign/api/v1beta1"
+	mimetype "github.com/rotationalio/go-ensign/mimetype/v1beta1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var seq uint32
+
+type EventFixture struct {
+	ID    string
+	Event *api.Event
+}
+
+// Return fake events
+func fixtureEvents() (events []*api.Event) {
+	events = make([]*api.Event, 0)
+
+	// Plaintext event
+	events = append(events, &api.Event{
+		Data:     []byte("hello world"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.TextPlain,
+		Type: &api.Type{
+			Name:         "Message",
+			MajorVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+
+	// CSV event
+	events = append(events, &api.Event{
+		Data:     []byte("hello,world"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.TextCSV,
+		Type: &api.Type{
+			Name:         "Spreadsheet",
+			MajorVersion: 1,
+			MinorVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+
+	// HTML event
+	events = append(events, &api.Event{
+		Data:     []byte("<html><body><h1>Hello World</h1></body></html>"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.TextHTML,
+		Type: &api.Type{
+			Name:         "Webpage",
+			MajorVersion: 1,
+			PatchVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+
+	// JSON events
+	events = append(events, &api.Event{
+		Data:     []byte(`{"price": 334.11, "symbol": "MSFT", "timestamp": 1690899527135, "volume": 50}`),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationJSON,
+		Type: &api.Type{
+			Name:         "StockQuote",
+			MinorVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+	events = append(events, &api.Event{
+		Data:     []byte(`{"price": 320.23, "symbol": "APPL", "timestamp": 1690899527135, "volume": 25}`),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationJSON,
+		Type: &api.Type{
+			Name:         "StockQuote",
+			MinorVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+	events = append(events, &api.Event{
+		Data:     []byte(`{"price": 335.12, "symbol": "MSFT", "timestamp": 1690899527135, "volume": 40}`),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationJSON,
+		Type: &api.Type{
+			Name:         "StockQuote",
+			MinorVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+
+	// XML event
+	events = append(events, &api.Event{
+		Data:     []byte(`<note><to>Arthur</to><from>Marvin</from><heading>Life</heading><body>Don't Panic!</body></note>`),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationXML,
+		Type: &api.Type{
+			Name:         "Note",
+			PatchVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+
+	// msgpack events
+	events = append(events, &api.Event{
+		Data:     []byte("\x81\xa4name\xa3Bob\xa3age\x18\x1e"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationMsgPack,
+		Type: &api.Type{
+			Name:         "Person",
+			MajorVersion: 1,
+			MinorVersion: 3,
+		},
+		Created: timestamppb.Now(),
+	})
+	events = append(events, &api.Event{
+		Data:     []byte("\x81\xa4name\xa3Alice\xa3age\x18\x1e"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationMsgPack,
+		Type: &api.Type{
+			Name:         "Person",
+			MajorVersion: 1,
+			MinorVersion: 3,
+		},
+		Created: timestamppb.Now(),
+	})
+
+	// protobuf events
+	events = append(events, &api.Event{
+		Data:     []byte("\x0a\x03Bob\x10\x1e"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationProtobuf,
+		Type: &api.Type{
+			Name:         "Person",
+			MajorVersion: 2,
+			PatchVersion: 1,
+		},
+		Created: timestamppb.Now(),
+	})
+	events = append(events, &api.Event{
+		Data:     []byte("\x0a\x05Alice\x10\x1e"),
+		Metadata: map[string]string{},
+		Mimetype: mimetype.ApplicationProtobuf,
+		Type: &api.Type{
+			Name:         "Person",
+			MajorVersion: 2,
+			PatchVersion: 1,
+		},
+	})
+
+	return events
+}

--- a/pkg/tenant/projects.go
+++ b/pkg/tenant/projects.go
@@ -2,8 +2,11 @@ package tenant
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -19,8 +22,11 @@ import (
 	"github.com/rotationalio/ensign/pkg/utils/sentry"
 	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	pb "github.com/rotationalio/go-ensign/api/v1beta1"
+	mt "github.com/rotationalio/go-ensign/mimetype/v1beta1"
 	"github.com/rs/zerolog/log"
 )
+
+const maxQueryResults = 10
 
 // TenantProjectList retrieves projects assigned to a specified
 // tenant and returns a 200 OK response.
@@ -781,6 +787,104 @@ func (s *Server) ProjectDelete(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// ProjectQuery executes simple queries on topics in a project using enSQL. This
+// endpoint forwards the query to Ensign and a limited number of results to the client.
+// Clients that require more results or complex queries should use the SDKs instead.
+//
+// Route: /projects/:projectID/query
+func (s *Server) ProjectQuery(c *gin.Context) {
+	var (
+		err       error
+		orgID     ulid.ULID
+		projectID ulid.ULID
+		in        *api.ProjectQueryRequest
+	)
+
+	// orgID is required to check ownership of the project
+	if orgID = orgIDFromContext(c); ulids.IsZero(orgID) {
+		return
+	}
+
+	if err = c.BindJSON(&in); err != nil {
+		log.Warn().Err(err).Msg("could not bind request")
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(api.ErrUnparsable))
+		return
+	}
+
+	// Get the project ID from the URL
+	if projectID, err = ulid.Parse(c.Param("projectID")); err != nil {
+		log.Warn().Err(err).Str("projectID", c.Param("projectID")).Msg("could not parse project id")
+		c.JSON(http.StatusNotFound, api.ErrorResponse(responses.ErrProjectNotFound))
+		return
+	}
+
+	// Verify that the project exists in the organization.
+	if err = db.VerifyOrg(c, orgID, projectID); err != nil {
+		if errors.Is(err, db.ErrNotFound) || errors.Is(err, db.ErrOrgNotVerified) {
+			c.JSON(http.StatusNotFound, api.ErrorResponse(responses.ErrProjectNotFound))
+			return
+		}
+		sentry.Warn(c).Err(err).Msg("could not check verification")
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse(responses.ErrSomethingWentWrong))
+		return
+	}
+
+	in.Query = strings.TrimSpace(in.Query)
+	if in.Query == "" {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(api.ErrMissingQueryField))
+		return
+	}
+
+	if len(in.Query) > 2000 {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse(api.ErrQueryTooLong))
+		return
+	}
+
+	// Build the response with the query results
+	out := &api.ProjectQueryResponse{
+		Results: make([]*api.QueryResult, 0),
+	}
+
+	// TODO: Query events from Ensign rather than using the fixtures
+	events := fixtureEvents()
+	for _, event := range events {
+		result := &api.QueryResult{
+			Metadata: event.Metadata,
+			Mimetype: event.Mimetype.MimeType(),
+			Version:  fmt.Sprintf("%s v%d.%d.%d", event.Type.Name, event.Type.MajorVersion, event.Type.MinorVersion, event.Type.PatchVersion),
+			Created:  event.Created.String(),
+		}
+
+		// Attempt to encode the event data.
+		if result.Data, result.IsBase64Encoded, err = encodeToString(event.Data, event.Mimetype); err != nil {
+			result.Data = "could not encode event data to string"
+		}
+
+		out.Results = append(out.Results, result)
+		if len(out.Results) >= maxQueryResults {
+			break
+		}
+	}
+
+	c.JSON(http.StatusOK, out)
+}
+
+// Encode event data into a string for the response. Returns true if the data was
+// base64 encoded.
+func encodeToString(data []byte, mime mt.MIME) (encoded string, isBase64Encoded bool, err error) {
+	switch mime {
+	case mt.TextPlain, mt.TextCSV, mt.TextHTML:
+		return string(data), false, nil
+	case mt.ApplicationJSON:
+		if encoded, err = responses.RemarshalJSON(data); err != nil {
+			return "", false, err
+		}
+		return encoded, false, nil
+	default:
+		return base64.StdEncoding.EncodeToString(data), true, nil
+	}
 }
 
 // createProject is a helper to create a project in the tenant database as well as

--- a/pkg/tenant/projects_test.go
+++ b/pkg/tenant/projects_test.go
@@ -3,6 +3,7 @@ package tenant_test
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1226,6 +1227,132 @@ func (suite *tenantTestSuite) TestProjectDelete() {
 
 	err = suite.client.ProjectDelete(ctx, projectID)
 	suite.requireError(err, http.StatusNotFound, "project not found", "expected error when project ID is not found")
+}
+
+func (suite *tenantTestSuite) TestProjectQuery() {
+	require := suite.Require()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Init the trtl mock
+	trtl := db.GetMock()
+	defer trtl.Reset()
+
+	project := &db.Project{
+		OrgID:    ulids.New(),
+		TenantID: ulids.New(),
+		ID:       ulids.New(),
+	}
+
+	// Configure the trtl mock to return success for org verification
+	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
+		switch gr.Namespace {
+		case db.OrganizationNamespace:
+			return &pb.GetReply{
+				Value: project.OrgID[:],
+			}, nil
+		default:
+			return nil, status.Errorf(codes.NotFound, "unknown namespace: %s", gr.Namespace)
+		}
+	}
+
+	// Set the initial claims fixture
+	claims := &tokens.Claims{
+		Name:        "Leopold Wentzel",
+		Email:       "leopold.wentzel@gmail.com",
+		Permissions: []string{"read:nothing"},
+	}
+
+	// Endpoint must be authenticated
+	req := &api.ProjectQueryRequest{
+		ProjectID: project.ID.String(),
+	}
+	require.NoError(suite.SetClientCSRFProtection(), "could not set csrf protection")
+	_, err := suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
+
+	// User must have the correct permissions
+	require.NoError(suite.SetClientCredentials(claims), "could not set client claims")
+	_, err = suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusUnauthorized, "user does not have permission to perform this operation", "expected error when user does not have permissions")
+
+	// Set valid permissions for the rest of the tests
+	claims.Permissions = []string{perms.ReadTopics}
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+
+	// Should return an error if user is not in the same org as the project.
+	claims.OrgID = "01GWT0E850YBSDQH0EQFXRCMGB"
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	_, err = suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusNotFound, responses.ErrProjectNotFound, "expected error when org verification fails")
+
+	// Should return an error if the project id is not parseable.
+	claims.OrgID = project.OrgID.String()
+	require.NoError(suite.SetClientCredentials(claims), "could not set client credentials")
+	req.ProjectID = "invalid"
+	_, err = suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusNotFound, responses.ErrProjectNotFound, "expected error when project ID is not parseable")
+
+	// Should return an error if the query is not provided.
+	req.ProjectID = project.ID.String()
+	_, err = suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusBadRequest, api.ErrMissingQueryField.Error(), "expected error when query is not provided")
+
+	// Should return an error if the query is too long.
+	req.Query = strings.Repeat("a", 2001)
+	_, err = suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusBadRequest, api.ErrQueryTooLong.Error(), "expected error when query is too long")
+
+	// Successfully retrieve query results.
+	expectedPlaintext := &api.QueryResult{
+		Metadata: map[string]string{},
+		Mimetype: "text/plain",
+		Version:  "Message v1.0.0",
+		Data:     "hello world",
+	}
+	req.Query = "SELECT * FROM topic LIMIT 10"
+	rep, err := suite.client.ProjectQuery(ctx, req)
+	require.NoError(err, "could not retrieve query results")
+	require.Empty(rep.Error, "expected no query error")
+	require.Len(rep.Results, 10, "expected 10 query results")
+
+	// Verify the plaintext fixture is returned
+	require.NotEmpty(rep.Results[0].Created, "empty created timestamp")
+	rep.Results[0].Created = ""
+	require.Equal(expectedPlaintext, rep.Results[0], "unexpected query result for plaintext fixture")
+
+	// Verify the JSON fixture is returned
+	expectedJSON := &api.QueryResult{
+		Metadata: map[string]string{},
+		Mimetype: "application/json",
+		Version:  "StockQuote v0.1.0",
+	}
+	require.Len(rep.Results[3].Data, 87, "unexpected JSON encoded data length")
+	rep.Results[3].Data = ""
+	require.NotEmpty(rep.Results[3].Created, "empty created timestamp")
+	rep.Results[3].Created = ""
+	require.Equal(expectedJSON, rep.Results[3], "unexpected query result for JSON fixture")
+
+	// Verify the protobuf fixture is returned
+	expectedProtobuf := &api.QueryResult{
+		Metadata:        map[string]string{},
+		Mimetype:        "application/protobuf",
+		Version:         "Person v2.0.1",
+		IsBase64Encoded: true,
+	}
+	require.NotEmpty(rep.Results[9].Created, "empty created timestamp")
+	rep.Results[9].Created = ""
+	_, err = base64.StdEncoding.DecodeString(rep.Results[9].Data)
+	require.NoError(err, "could not decode protobuf fixture from base64")
+	rep.Results[9].Data = ""
+	require.Equal(expectedProtobuf, rep.Results[9], "unexpected query result for protobuf fixture")
+
+	// Should return an error if the project ID is parsed but not found.
+	trtl.OnGet = func(ctx context.Context, gr *pb.GetRequest) (*pb.GetReply, error) {
+		return nil, status.Errorf(codes.NotFound, "project not found")
+	}
+	_, err = suite.client.ProjectQuery(ctx, req)
+	suite.requireError(err, http.StatusNotFound, responses.ErrProjectNotFound, "expected error when project ID is not found")
 }
 
 func (suite *tenantTestSuite) TestUpdateProjectStats() {

--- a/pkg/tenant/tenant.go
+++ b/pkg/tenant/tenant.go
@@ -342,6 +342,8 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 
 			projects.GET("/:projectID/apikeys", mw.Authorize(perms.ReadAPIKeys), s.ProjectAPIKeyList)
 			projects.POST("/:projectID/apikeys", csrf, mw.Authorize(perms.EditAPIKeys), s.ProjectAPIKeyCreate)
+
+			projects.POST("/:projectID/query", mw.Authorize(perms.ReadTopics), s.ProjectQuery)
 		}
 
 		// Topics API routes must be authenticated

--- a/pkg/utils/responses/marshal.go
+++ b/pkg/utils/responses/marshal.go
@@ -1,0 +1,16 @@
+package responses
+
+import "encoding/json"
+
+// Remarshal JSON data into a more readable string.
+func RemarshalJSON(data []byte) (string, error) {
+	var obj interface{}
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", err
+	}
+	pretty, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(pretty), nil
+}


### PR DESCRIPTION
### Scope of changes

This adds an initial endpoint in Tenant for doing topic queries, currently hardcoded fixtures are used to unblock the frontend so there is more work to be done here to get this fully working.

Fixes SC-19466

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This takes in the EnSQL query from the FE and returns maximum of 10 results in the response.
The result is either one of the standard errors (401 or 500, etc) or an error if the EnSQL query returns an error.

This needs to format the events for the response
(JSON - ensure proper spacing & indentation)
(Binary format - return base64 encoded version)

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

