### PR TITLE
Name Group Corrupted Bug

### DIFF
--- a/pkg/ensign/events.go
+++ b/pkg/ensign/events.go
@@ -517,7 +517,11 @@ func (s *StreamHandler) AllowedTopics() (group *topics.NameGroup, err error) {
 			sentry.Error(s.stream.Context()).Err(err).Str("topicID", topicID.String()).Msg("could not get topic name from ID")
 			return nil, status.Errorf(codes.Internal, "could not open %s stream", s.stype)
 		}
-		group.Add(name, topicID)
+
+		if err := group.Add(name, topicID); err != nil {
+			sentry.Error(s.stream.Context()).Err(err).Str("topicID", topicID.String()).Str("topic", name).Msg("could not add topic name and ID to group")
+			return nil, status.Errorf(codes.Internal, "could not open %s stream", s.stype)
+		}
 	}
 
 	if group.Length() == 0 {

--- a/pkg/ensign/topics/topics_test.go
+++ b/pkg/ensign/topics/topics_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/topics"
+	"github.com/rotationalio/ensign/pkg/utils/ulids"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,4 +126,38 @@ func TestNameGroupFilterName(t *testing.T) {
 			require.True(t, filtered.Contains(fixture.id.String()))
 		}
 	}
+}
+
+func TestEmptyNameGroup(t *testing.T) {
+	group := &topics.NameGroup{}
+	require.Equal(t, 0, group.Length())
+
+	// TODO: should this continue to be empty?
+	group.Add("", ulids.Null)
+	require.Equal(t, 1, group.Length())
+
+	group.Add("", ulids.Null)
+	require.Equal(t, 1, group.Length())
+}
+
+func TestAddTopicIDTwice(t *testing.T) {
+	topicID := ulid.MustParse("01H78XH126J1XHRR2CAQBBT7RC")
+	group := &topics.NameGroup{}
+
+	group.Add("foo", topicID)
+	group.Add("bar", topicID)
+
+	// TODO: this should not panic
+	require.Panics(t, func() { group.Length() })
+	// require.Equal(t, 1, group.Length())
+}
+
+func TestAddTopicNameTwice(t *testing.T) {
+	group := &topics.NameGroup{}
+	group.Add("foo", ulid.MustParse("01H78XH126J1XHRR2CAQBBT7RC"))
+	group.Add("foo", ulid.MustParse("01H78XT88RRYKX9SFQNN47B7WK"))
+
+	// TODO: this should not panic
+	require.Panics(t, func() { group.Length() })
+	// require.Equal(t, 1, group.Length())
 }

--- a/pkg/ensign/topics/topics_test.go
+++ b/pkg/ensign/topics/topics_test.go
@@ -22,7 +22,7 @@ func TestNameGroup(t *testing.T) {
 	require.False(t, group.Contains(hash1))
 
 	// Add name and ID
-	group.Add(name1, ulid.MustParse(tids1))
+	require.NoError(t, group.Add(name1, ulid.MustParse(tids1)))
 	require.True(t, group.Contains(name1))
 	require.True(t, group.Contains(tids1))
 	require.True(t, group.Contains(hash1))
@@ -69,7 +69,7 @@ func TestNameGroupFilterID(t *testing.T) {
 
 	group := &topics.NameGroup{}
 	for _, fixture := range fixtures {
-		group.Add(fixture.name, fixture.id)
+		require.NoError(t, group.Add(fixture.name, fixture.id))
 	}
 
 	filtered := group.FilterTopicID(fixtures[1].id, fixtures[3].id, fixtures[5].id, fixtures[7].id)
@@ -107,7 +107,7 @@ func TestNameGroupFilterName(t *testing.T) {
 
 	group := &topics.NameGroup{}
 	for _, fixture := range fixtures {
-		group.Add(fixture.name, fixture.id)
+		require.NoError(t, group.Add(fixture.name, fixture.id))
 	}
 
 	filtered := group.FilterTopicName(fixtures[1].name, fixtures[3].name, fixtures[5].name, fixtures[7].name)
@@ -132,32 +132,38 @@ func TestEmptyNameGroup(t *testing.T) {
 	group := &topics.NameGroup{}
 	require.Equal(t, 0, group.Length())
 
-	// TODO: should this continue to be empty?
-	group.Add("", ulids.Null)
-	require.Equal(t, 1, group.Length())
+	err := group.Add("", ulids.Null)
+	require.ErrorIs(t, err, topics.ErrEmptyReference)
+	require.Equal(t, 0, group.Length())
 
-	group.Add("", ulids.Null)
-	require.Equal(t, 1, group.Length())
+	err = group.Add("", ulid.MustParse("01H78XH126J1XHRR2CAQBBT7RC"))
+	require.ErrorIs(t, err, topics.ErrEmptyReference)
+	require.Equal(t, 0, group.Length())
+
+	err = group.Add("example", ulids.Null)
+	require.ErrorIs(t, err, topics.ErrEmptyReference)
+	require.Equal(t, 0, group.Length())
 }
 
 func TestAddTopicIDTwice(t *testing.T) {
 	topicID := ulid.MustParse("01H78XH126J1XHRR2CAQBBT7RC")
 	group := &topics.NameGroup{}
 
-	group.Add("foo", topicID)
-	group.Add("bar", topicID)
+	require.NoError(t, group.Add("foo", topicID))
+	require.Equal(t, 1, group.Length())
 
-	// TODO: this should not panic
-	require.Panics(t, func() { group.Length() })
-	// require.Equal(t, 1, group.Length())
+	err := group.Add("bar", topicID)
+	require.ErrorIs(t, err, topics.ErrAlreadyExists)
+	require.Equal(t, 1, group.Length())
 }
 
 func TestAddTopicNameTwice(t *testing.T) {
 	group := &topics.NameGroup{}
-	group.Add("foo", ulid.MustParse("01H78XH126J1XHRR2CAQBBT7RC"))
-	group.Add("foo", ulid.MustParse("01H78XT88RRYKX9SFQNN47B7WK"))
 
-	// TODO: this should not panic
-	require.Panics(t, func() { group.Length() })
-	// require.Equal(t, 1, group.Length())
+	require.NoError(t, group.Add("foo", ulid.MustParse("01H78XH126J1XHRR2CAQBBT7RC")))
+	require.Equal(t, 1, group.Length())
+
+	err := group.Add("foo", ulid.MustParse("01H78XT88RRYKX9SFQNN47B7WK"))
+	require.ErrorIs(t, err, topics.ErrAlreadyExists)
+	require.Equal(t, 1, group.Length())
 }


### PR DESCRIPTION
### Scope of changes

Fixes name group corrupted bug when duplicate topicIDs or topic names are added to the name group.

Fixes SC-19710

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Fixes the bug. 

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [x] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

