### PR TITLE
Add metrics permissions to project access

### DIFF
--- a/pkg/quarterdeck/projects.go
+++ b/pkg/quarterdeck/projects.go
@@ -204,10 +204,10 @@ func (s *Server) ProjectAccess(c *gin.Context) {
 		Permissions: make([]string, 0, 4),
 	}
 
-	// Add only the user permissions related to topics to these claims -- whatever
-	// access to topics the user has, so to will the one time access claims.
+	// Add only the user permissions related to topics and metrics to these claims -- whatever
+	// access to topics and metrics the user has, so to will the one time access claims.
 	for _, permission := range claims.Permissions {
-		if permissions.InGroup(permission, permissions.PrefixTopics) {
+		if permissions.InGroup(permission, permissions.PrefixTopics) || permissions.InGroup(permission, permissions.PrefixMetrics) {
 			ota.Permissions = append(ota.Permissions, permission)
 		}
 	}

--- a/pkg/quarterdeck/projects_test.go
+++ b/pkg/quarterdeck/projects_test.go
@@ -134,7 +134,7 @@ func (s *quarterdeckTestSuite) TestProjectAccess() {
 	// Create valid claims for accessing the API
 	claims.Subject = "01GKHJSK7CZW0W282ZN3E9W86Z"
 	claims.OrgID = "01GKHJRF01YXHZ51YMMKV3RCMK"
-	claims.Permissions = []string{perms.ReadAPIKeys, perms.ReadTopics, perms.DeleteAPIKeys, perms.CreateTopics, perms.EditAPIKeys}
+	claims.Permissions = []string{perms.ReadAPIKeys, perms.ReadTopics, perms.DeleteAPIKeys, perms.CreateTopics, perms.EditAPIKeys, perms.ReadMetrics}
 	ctx = s.AuthContext(ctx, claims)
 
 	// Test Happy Path
@@ -158,7 +158,7 @@ func (s *quarterdeckTestSuite) TestProjectAccess() {
 	require.Equal(claims.Subject, ota.Subject)
 	require.Equal(claims.OrgID, ota.OrgID)
 	require.Equal(req.ProjectID.String(), ota.ProjectID)
-	require.Equal([]string{perms.ReadTopics, perms.CreateTopics}, ota.Permissions)
+	require.Equal([]string{perms.ReadTopics, perms.CreateTopics, perms.ReadMetrics}, ota.Permissions)
 	require.Greater(time.Until(ota.ExpiresAt.Time), 1*time.Minute)
 	require.Less(time.Until(ota.ExpiresAt.Time), 10*time.Minute)
 


### PR DESCRIPTION
### Scope of changes

This fixes a bug where the project status was not updating on the frontend. It's actually a bug in the backend where the project access endpoint was not giving out the `metrics:read` permission. This is required now due to a permissions change on the project info RPC in Ensign - users now need both `topics:read` and `metrics:read` to fetch the project info.

Fixes SC-19869

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Found from sentry issue:

Sentry Issue: [TENANT-S](https://rotational-labs.sentry.io/issues/4064654677/?referrer=Shortcut)

```
*tasks.Error: after 1 retries: could not update stats for project 01H7B9Z8TDJ6KQTATTD8F2THGW
  File "/go/src/github.com/rotationalio/ensign/pkg/utils/tasks/error.go", line 78, in (*Error).Capture
  File "/go/src/github.com/rotationalio/ensign/pkg/utils/tasks/tasks.go", line 182, in (*TaskHandler).Exec
  File "/go/src/github.com/rotationalio/ensign/pkg/utils/tasks/tasks.go", line 270, in TaskWorker
```

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [x] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [x] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

