### PR TITLE
Avoid divide by zero in topic events

### DIFF
--- a/pkg/tenant/topics.go
+++ b/pkg/tenant/topics.go
@@ -427,21 +427,27 @@ func (s *Server) TopicEvents(c *gin.Context) {
 				Version:  typeInfo.Type.Semver(),
 				Mimetype: typeInfo.Mimetype.MimeType(),
 				Events: &api.StatValue{
-					Name:    "events",
-					Value:   float64(typeInfo.Events),
-					Percent: (float64(typeInfo.Events) / float64(topic.Events)) * 100,
+					Name:  "events",
+					Value: float64(typeInfo.Events),
 				},
 				Duplicates: &api.StatValue{
-					Name:    "duplicates",
-					Value:   float64(typeInfo.Duplicates),
-					Percent: (float64(typeInfo.Duplicates) / float64(topic.Duplicates)) * 100,
+					Name:  "duplicates",
+					Value: float64(typeInfo.Duplicates),
 				},
 				Storage: &api.StatValue{
-					Name:    "storage",
-					Percent: (float64(typeInfo.DataSizeBytes) / float64(topic.DataSizeBytes)) * 100,
+					Name: "storage",
 				},
 			}
+			if topic.Events > 0 {
+				info.Events.Percent = (float64(typeInfo.Events) / float64(topic.Events)) * 100
+			}
+			if topic.Duplicates > 0 {
+				info.Duplicates.Percent = (float64(typeInfo.Duplicates) / float64(topic.Duplicates)) * 100
+			}
 			info.Storage.Units, info.Storage.Value = units.FromBytes(typeInfo.DataSizeBytes)
+			if topic.DataSizeBytes > 0 {
+				info.Storage.Percent = (float64(typeInfo.DataSizeBytes) / float64(topic.DataSizeBytes)) * 100
+			}
 			out = append(out, info)
 		}
 

--- a/pkg/tenant/topics_test.go
+++ b/pkg/tenant/topics_test.go
@@ -819,6 +819,20 @@ func (suite *tenantTestSuite) TestTopicEvents() {
 	require.NoError(err, "could not get topic events")
 	require.Equal(expected, infoReply, "wrong topic event data returned")
 
+	// Tenant should handle zero values for the totals, don't divide by zero
+	info.Topics[0].Events = 0
+	info.Topics[0].Duplicates = 0
+	info.Topics[0].DataSizeBytes = 0
+	expected[0].Events.Percent = 0
+	expected[0].Duplicates.Percent = 0
+	expected[0].Storage.Percent = 0
+	expected[1].Events.Percent = 0
+	expected[1].Duplicates.Percent = 0
+	expected[1].Storage.Percent = 0
+	infoReply, err = suite.client.TopicEvents(ctx, topicID.String())
+	require.NoError(err, "could not get topic events")
+	require.Equal(expected, infoReply, "wrong topic event data returned")
+
 	// Quarterdeck should only be called once, subsequent calls should use the token cache
 	_, err = suite.client.TopicEvents(ctx, topicID.String())
 	require.NoError(err, "could not get topic events on second call")


### PR DESCRIPTION
### Scope of changes

This fixes an issue where the event breakdown data was not serialized correctly for the HTTP response because we were dividing by zero.

Fixes SC-20179

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

[Front-End: add screenshots/videos of changes made]

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

