### PR TITLE
Fix EnSQL parsing of topics with - in the name

### DIFF
--- a/pkg/ensign/ensql/ensql.go
+++ b/pkg/ensign/ensql/ensql.go
@@ -631,7 +631,7 @@ func (p *parser) peekNumeric() Token {
 }
 
 var (
-	identre = regexp.MustCompile(`[a-zA-Z0-9_]`)
+	identre = regexp.MustCompile(`[a-zA-Z0-9_-]`)
 	boolre  = regexp.MustCompile(`^(1|t|T|True|true|TRUE|0|f|F|False|false|FALSE)$`)
 )
 

--- a/pkg/ensign/ensql/ensql_test.go
+++ b/pkg/ensign/ensql/ensql_test.go
@@ -442,6 +442,24 @@ func TestParse(t *testing.T) {
 			Expected: nil,
 			Err:      "syntax error at position 32 near \"red\": invalid where clause",
 		},
+		{
+			Name:     "topic with dash",
+			SQL:      "SELECT * FROM dashed-topic",
+			Expected: &Query{Type: SelectQuery, Fields: []Token{{"*", Asterisk, 1}}, Topic: Topic{Topic: "dashed-topic"}},
+			Err:      "",
+		},
+		{
+			Name:     "topic with underscore",
+			SQL:      "SELECT * FROM underscore_topic",
+			Expected: &Query{Type: SelectQuery, Fields: []Token{{"*", Asterisk, 1}}, Topic: Topic{Topic: "underscore_topic"}},
+			Err:      "",
+		},
+		{
+			Name:     "topic with numbers in it",
+			SQL:      "SELECT * FROM topic1234",
+			Expected: &Query{Type: SelectQuery, Fields: []Token{{"*", Asterisk, 1}}, Topic: Topic{Topic: "topic1234"}},
+			Err:      "",
+		},
 	}
 
 	for _, tc := range ts {
@@ -459,6 +477,7 @@ func TestParse(t *testing.T) {
 				// Add the raw field to make it easier to compose tests cases
 				tc.Expected.Raw = tc.SQL
 
+				require.NoError(t, err, "could not parse a query that was expected to be valid")
 				require.NotNil(t, actual, "expected a non-nil query tree")
 				require.Equal(t, tc.Expected, &actual, "actual query tree did not match test case expectation")
 			}


### PR DESCRIPTION
### Scope of changes

Added `-` to the identity regular expression and added topic name tests for topics with `-`, `_`, and numbers in them. Note that topics are allowed to have `.` in them, but these will have to be escaped in EnSQL which is a future TODO.

Fixes SC-20161

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This PR will be merged without review.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [x] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [x] Are there any TODOs in this PR that should be turned into stories?

