### PR TITLE
Fix Quarterdeck Middleware Cookie Max Age

### DIFF
--- a/pkg/quarterdeck/middleware/auth.go
+++ b/pkg/quarterdeck/middleware/auth.go
@@ -200,12 +200,12 @@ func TaskContext(c *gin.Context) (ctx context.Context) {
 	return ctx
 }
 
-// SetAuthTokens is a helper function to set authentication cookies on a gin request.
+// SetAuthCookies is a helper function to set authentication cookies on a gin request.
 // The access token cookie (access_token) is an http only cookie that expires when the
 // access token expires. The refresh token cookie is not an http only cookie (it can be
 // accessed by client-side scripts) and it expires when the refresh token expires. Both
 // cookies require https and will not be set (silently) over http connections.
-func SetAuthTokens(c *gin.Context, accessToken, refreshToken, domain string) (err error) {
+func SetAuthCookies(c *gin.Context, accessToken, refreshToken, domain string) (err error) {
 	// Parse access token to get expiration time
 	var accessExpires time.Time
 	if accessExpires, err = tokens.ExpiresAt(accessToken); err != nil {
@@ -213,7 +213,7 @@ func SetAuthTokens(c *gin.Context, accessToken, refreshToken, domain string) (er
 	}
 
 	// Set the access token cookie: httpOnly is true; cannot be accessed by Javascript
-	accessMaxAge := int((time.Until(accessExpires)))
+	accessMaxAge := int((time.Until(accessExpires)).Seconds())
 	c.SetCookie(AccessTokenCookie, accessToken, accessMaxAge, "/", domain, true, true)
 
 	// Parse refresh token to get expiration time

--- a/pkg/quarterdeck/middleware/auth_test.go
+++ b/pkg/quarterdeck/middleware/auth_test.go
@@ -171,7 +171,7 @@ func TestGetAccessTokenCookie(t *testing.T) {
 			return
 		}
 
-		middleware.SetAuthTokens(c, access, refresh, "127.0.0.1")
+		middleware.SetAuthCookies(c, access, refresh, "127.0.0.1")
 		c.JSON(http.StatusOK, gin.H{"success": true})
 	})
 

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -258,7 +258,7 @@ func (s *Server) Login(c *gin.Context) {
 	}
 
 	// Set the access and refresh tokens as cookies for the front-end
-	if err := middleware.SetAuthTokens(c, reply.AccessToken, reply.RefreshToken, s.conf.Auth.CookieDomain); err != nil {
+	if err := middleware.SetAuthCookies(c, reply.AccessToken, reply.RefreshToken, s.conf.Auth.CookieDomain); err != nil {
 		sentry.Error(c).Err(err).Msg("could not set access and refresh token cookies")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse(responses.ErrSomethingWentWrong))
 		return
@@ -330,7 +330,7 @@ func (s *Server) Refresh(c *gin.Context) {
 	}
 
 	// Set the access and refresh tokens as cookies for the front-end
-	if err := middleware.SetAuthTokens(c, reply.AccessToken, reply.RefreshToken, s.conf.Auth.CookieDomain); err != nil {
+	if err := middleware.SetAuthCookies(c, reply.AccessToken, reply.RefreshToken, s.conf.Auth.CookieDomain); err != nil {
 		sentry.Error(c).Err(err).Msg("could not set access and refresh token cookies")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse(responses.ErrSomethingWentWrong))
 		return
@@ -427,7 +427,7 @@ func (s *Server) Switch(c *gin.Context) {
 	}
 
 	// Set the access and refresh tokens as cookies for the front-end
-	if err = middleware.SetAuthTokens(c, reply.AccessToken, reply.RefreshToken, s.conf.Auth.CookieDomain); err != nil {
+	if err = middleware.SetAuthCookies(c, reply.AccessToken, reply.RefreshToken, s.conf.Auth.CookieDomain); err != nil {
 		sentry.Error(c).Err(err).Msg("could not set access and refresh token cookies")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not set auth cookies"))
 		return


### PR DESCRIPTION
### Scope of changes

Fixes a Quarterdeck bug where the access token cookie was not being expired correctly.

Fixes SC-20254

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

The cookie maxAge should be defined in seconds, not nanoseconds.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [x] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

