### PR TITLE
Fix Committed Timestamp Bug

### DIFF
--- a/pkg/ensign/broker/broker.go
+++ b/pkg/ensign/broker/broker.go
@@ -283,6 +283,9 @@ func (b *Broker) isRunning() bool {
 func (b *Broker) result(in incoming, result PublishResult) {
 	b.pubmu.RLock()
 	if cb, ok := b.pubs[in.pubID]; ok {
+		// Ensure the committed timestamp from the event is added to the result
+		result.Committed = in.event.Committed
+
 		// Non-blocking send so non-responding publishers don't hurt performance.
 		select {
 		case cb <- result:

--- a/pkg/ensign/broker/msgs.go
+++ b/pkg/ensign/broker/msgs.go
@@ -1,8 +1,6 @@
 package broker
 
 import (
-	"time"
-
 	"github.com/oklog/ulid/v2"
 	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/rlid"
@@ -15,10 +13,10 @@ import (
 // processed by the broker (e.g. not committed, not written, etc.) then the result will
 // contain a Nack message.
 type PublishResult struct {
-	LocalID   []byte        // The localID on the event sent by the publisher for client-side correlation
-	Committed time.Time     // The timestamp the event was committed (if it was committed)
-	Code      api.Nack_Code // The reason why the result errored; if not unknown the result is treated as an error
-	Error     string        // An error message, should be set if the nack code is set
+	LocalID   []byte                 // The localID on the event sent by the publisher for client-side correlation
+	Committed *timestamppb.Timestamp // The timestamp the event was committed (if it was committed)
+	Code      api.Nack_Code          // The reason why the result errored; if not unknown the result is treated as an error
+	Error     string                 // An error message, should be set if the nack code is set
 }
 
 // Returns true if the reply is an ack, false if it is a nack
@@ -55,7 +53,7 @@ func (p PublishResult) Reply() *api.PublisherReply {
 func (p PublishResult) Ack() *api.Ack {
 	return &api.Ack{
 		Id:        p.LocalID,
-		Committed: timestamppb.New(p.Committed),
+		Committed: p.Committed,
 	}
 }
 

--- a/pkg/ensign/broker/msgs_test.go
+++ b/pkg/ensign/broker/msgs_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/rotationalio/ensign/pkg/ensign/broker"
 	"github.com/rotationalio/ensign/pkg/ensign/rlid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestPublishResultAck(t *testing.T) {
 	res := broker.PublishResult{
 		LocalID:   rlid.Make(42).Bytes(),
-		Committed: time.Date(2023, 8, 32, 14, 18, 23, 0, time.UTC),
+		Committed: timestamppb.New(time.Date(2023, 8, 32, 14, 18, 23, 0, time.UTC)),
 	}
 
 	// Test Ack from result
@@ -23,7 +24,7 @@ func TestPublishResultAck(t *testing.T) {
 	ack, ok := rep.Embed.(*api.PublisherReply_Ack)
 	require.True(t, ok, "expected an ack to be returned")
 	require.Equal(t, res.LocalID, ack.Ack.Id)
-	require.True(t, res.Committed.Equal(ack.Ack.Committed.AsTime()))
+	require.True(t, res.Committed.AsTime().Equal(ack.Ack.Committed.AsTime()))
 }
 
 func TestPublishResultNack(t *testing.T) {

--- a/pkg/ensign/events_test.go
+++ b/pkg/ensign/events_test.go
@@ -415,7 +415,7 @@ func TestPublisherHandler(t *testing.T) {
 
 		ack := broker.PublishResult{
 			LocalID:   ulid.Make().Bytes(),
-			Committed: time.Now(),
+			Committed: timestamppb.Now(),
 		}
 		nack := broker.PublishResult{
 			LocalID: ulid.Make().Bytes(),


### PR DESCRIPTION
### Scope of changes

Fixes the invalid committed timestamp bug on the broker.

Fixes SC-20852

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This bug fix was implemented by @pdamodaran and @pdeziel with @bbengfort during the Broker code tour.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

