### PR TITLE
Profile update check domain

### DIFF
--- a/pkg/quarterdeck/mock/quarterdeck.go
+++ b/pkg/quarterdeck/mock/quarterdeck.go
@@ -25,6 +25,7 @@ const (
 	OrganizationsEP = "/v1/organizations"
 	UsersEP         = "/v1/users"
 	InvitesEP       = "/v1/invites"
+	WorkspaceEP     = "/v1/workspace"
 )
 
 // Server embeds an httptest Server and provides additional methods for configuring
@@ -328,6 +329,10 @@ func (s *Server) OnInvitesAccept(opts ...HandlerOption) {
 	s.setHandler(http.MethodPost, fullPath(InvitesEP, "accept"), opts...)
 }
 
+func (s *Server) OnWorkspace(opts ...HandlerOption) {
+	s.setHandler(http.MethodGet, WorkspaceEP, opts...)
+}
+
 func (s *Server) count(requestKey string) int {
 	s.RLock()
 	defer s.RUnlock()
@@ -445,4 +450,8 @@ func (s *Server) InvitesCreateCount() int {
 
 func (s *Server) InvitesAcceptCount() int {
 	return s.count(methodPath(http.MethodPost, fullPath(InvitesEP, "accept")))
+}
+
+func (s *Server) WorkspaceCount() int {
+	return s.count(methodPath(http.MethodGet, WorkspaceEP))
 }

--- a/pkg/tenant/db/db_test.go
+++ b/pkg/tenant/db/db_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/tenant/config"
 	"github.com/rotationalio/ensign/pkg/tenant/db"
+	"github.com/rotationalio/ensign/pkg/utils/logger"
 	pg "github.com/rotationalio/ensign/pkg/utils/pagination"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -31,6 +32,10 @@ type dbTestSuite struct {
 
 func (s *dbTestSuite) SetupSuite() {
 	require := s.Require()
+
+	// Reduce logging clutter for tests
+	logger.Discard()
+
 	require.NoError(db.Connect(config.DatabaseConfig{Testing: true}), "unable to connect to db in testing mode")
 	require.True(db.IsTesting(), "expected database to be in testing mode")
 	require.True(db.IsConnected(), "expected database to be connected in testing mode")


### PR DESCRIPTION
### Scope of changes

This adds a workspace domain check to the profile update endpoint so that we can return an error to the frontend if the domain is already taken, before attempting to make any organization updates to Quarterdeck.

Fixes SC-20619

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

[Front-End: add screenshots/videos of changes made]

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

