### PR TITLE
Quarterdeck Resend Email Endpoint

### DIFF
--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -23,6 +23,7 @@ type QuarterdeckClient interface {
 	Refresh(context.Context, *RefreshRequest) (*LoginReply, error)
 	Switch(context.Context, *SwitchRequest) (*LoginReply, error)
 	VerifyEmail(context.Context, *VerifyRequest) error
+	ResendEmail(context.Context, *ResendRequest) error
 
 	// Organizations Resource
 	OrganizationDetail(context.Context, string) (*Organization, error)
@@ -173,6 +174,10 @@ type SwitchRequest struct {
 
 type VerifyRequest struct {
 	Token string `json:"token"`
+}
+
+type ResendRequest struct {
+	Email string `json:"email"`
 }
 
 //===========================================================================

--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -177,7 +177,8 @@ type VerifyRequest struct {
 }
 
 type ResendRequest struct {
-	Email string `json:"email"`
+	Email string    `json:"email"`
+	OrgID ulid.ULID `json:"org_id,omitempty"`
 }
 
 //===========================================================================

--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -169,6 +169,19 @@ func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (err error) 
 	return nil
 }
 
+func (s *APIv1) ResendEmail(ctx context.Context, in *ResendRequest) (err error) {
+	var req *http.Request
+	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/resend", in, nil); err != nil {
+		return err
+	}
+
+	if _, err = s.Do(req, nil, true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 //===========================================================================
 // Organization Resource
 //===========================================================================

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -295,6 +295,27 @@ func TestVerifyEmail(t *testing.T) {
 	require.NoError(t, err, "could not execute api request")
 }
 
+func TestResendEmail(t *testing.T) {
+	// Setup the response fixture
+	fixture := &api.Reply{
+		Success: true,
+	}
+
+	// Create a test server
+	ts := httptest.NewServer(testhandler(fixture, http.MethodPost, "/v1/resend"))
+	defer ts.Close()
+
+	// Create a client and execute endpoint request
+	client, err := api.New(ts.URL)
+	require.NoError(t, err, "could not create api client")
+
+	req := &api.ResendRequest{
+		Email: "frank@example.com",
+	}
+	err = client.ResendEmail(context.Background(), req)
+	require.NoError(t, err, "could not execute api request")
+}
+
 //===========================================================================
 // Organization Resource
 //===========================================================================

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -275,12 +275,8 @@ func TestSwitch(t *testing.T) {
 }
 
 func TestVerifyEmail(t *testing.T) {
-	// Setup the response fixture
-	fixture := &api.Reply{
-		Success: true,
-	}
-
-	// Create a test server
+	// Create a test server with a simple response fixture.
+	fixture := &api.Reply{Success: true}
 	ts := httptest.NewServer(testhandler(fixture, http.MethodPost, "/v1/verify"))
 	defer ts.Close()
 
@@ -288,20 +284,14 @@ func TestVerifyEmail(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err, "could not create api client")
 
-	req := &api.VerifyRequest{
-		Token: "1234567890",
-	}
+	req := &api.VerifyRequest{Token: "1234567890"}
 	err = client.VerifyEmail(context.TODO(), req)
 	require.NoError(t, err, "could not execute api request")
 }
 
 func TestResendEmail(t *testing.T) {
-	// Setup the response fixture
-	fixture := &api.Reply{
-		Success: true,
-	}
-
-	// Create a test server
+	// Create a test server with a simple response fixture.
+	fixture := &api.Reply{Success: true}
 	ts := httptest.NewServer(testhandler(fixture, http.MethodPost, "/v1/resend"))
 	defer ts.Close()
 
@@ -309,9 +299,7 @@ func TestResendEmail(t *testing.T) {
 	client, err := api.New(ts.URL)
 	require.NoError(t, err, "could not create api client")
 
-	req := &api.ResendRequest{
-		Email: "frank@example.com",
-	}
+	req := &api.ResendRequest{Email: "frank@example.com"}
 	err = client.ResendEmail(context.Background(), req)
 	require.NoError(t, err, "could not execute api request")
 }

--- a/pkg/quarterdeck/auth_test.go
+++ b/pkg/quarterdeck/auth_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/api/v1"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/db/models"
+	"github.com/rotationalio/ensign/pkg/quarterdeck/passwd"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/tokens"
 	"github.com/rotationalio/ensign/pkg/utils/emails"
 	"github.com/rotationalio/ensign/pkg/utils/emails/mock"
+	"github.com/rotationalio/ensign/pkg/utils/random"
 	"github.com/rotationalio/ensign/pkg/utils/responses"
 	"github.com/rotationalio/ensign/pkg/utils/ulids"
 )
@@ -687,4 +689,70 @@ func (s *quarterdeckTestSuite) TestVerify() {
 		},
 	}
 	mock.CheckEmails(s.T(), messages)
+}
+
+func (s *quarterdeckTestSuite) TestResendEmail() {
+	require := s.Require()
+	defer s.ResetDatabase()
+
+	// Create a new user that will not receive a verification email
+	user := &models.User{
+		Name:  "Killian Slowpoke",
+		Email: "killian@slowpoke.co.uk",
+	}
+
+	user.SetAgreement(true, true)
+	user.Password, _ = passwd.CreateDerivedKey("itsapirateslifeforme")
+	user.CreateVerificationToken()
+
+	org := &models.Organization{Domain: random.Name(7)}
+	err := user.Create(context.Background(), org, permissions.RoleOwner)
+	require.NoError(err, "could not create a new user that does not receive a verification token")
+
+	s.Run("ResendVerifyEmail", func() {
+		defer mock.Reset() // reset the emails mock
+
+		req := &api.ResendRequest{Email: "killian@slowpoke.co.uk"}
+		err := s.client.ResendEmail(context.Background(), req)
+		require.NoError(err, "unable to resend email")
+
+		// Ensure old verification token is invalidated
+		killian, err := models.GetUserEmail(context.Background(), "killian@slowpoke.co.uk", "")
+		require.NoError(err, "could not fetch user")
+		require.NotEqual(user.EmailVerificationToken, killian.EmailVerificationToken, "expected a new token to be created")
+
+		// Ensure the email verification was sent
+		messages := []*mock.EmailMeta{
+			{
+				To:      "killian@slowpoke.co.uk",
+				From:    s.conf.SendGrid.FromEmail,
+				Subject: "Please verify your email address to login to Ensign",
+			},
+		}
+
+		s.StopTasks()
+		mock.CheckEmails(s.T(), messages)
+	})
+
+	s.Run("AlreadyVerified", func() {
+		defer mock.Reset() // reset the emails mock
+
+		req := &api.ResendRequest{Email: "zendaya@testing.io"}
+		err := s.client.ResendEmail(context.Background(), req)
+		require.NoError(err, "unable to resend email")
+
+		s.StopTasks()
+		mock.CheckEmails(s.T(), nil)
+	})
+
+	s.Run("UnknownUser", func() {
+		defer mock.Reset() // reset the emails mock
+
+		req := &api.ResendRequest{Email: "invalid@unknown.fr"}
+		err := s.client.ResendEmail(context.Background(), req)
+		require.NoError(err, "unable to resend email")
+
+		s.StopTasks()
+		mock.CheckEmails(s.T(), nil)
+	})
 }

--- a/pkg/quarterdeck/db/models/users.go
+++ b/pkg/quarterdeck/db/models/users.go
@@ -1022,7 +1022,7 @@ func (u *User) revokeKeys(tx *sql.Tx, orgID ulid.ULID) (err error) {
 }
 
 // Fetches the organization roles and permissions for the specified orgID. If the orgID
-// is Null then one of the user's organizations is used. If the user is not part of the
+// is empty then one of the user's organizations is used. If the user is not part of the
 // organization with that orgID then an error is returned and the orgID on the user is
 // not set or changed. This method is used by the GetUser methods as well as the
 // SwitchOrganization method but with two different external contexts and validations.

--- a/pkg/quarterdeck/orgs.go
+++ b/pkg/quarterdeck/orgs.go
@@ -226,7 +226,13 @@ func (s *Server) OrganizationUpdate(c *gin.Context) {
 	c.JSON(http.StatusOK, org.ToAPI())
 }
 
-// Lookup an organization's workspace by domain slug.
+// Lookup an organization's workspace by domain slug. This authenticated GET request
+// expects the read:organizations permission from the user. It also expects a query
+// parameter domain, otherwise a 400 bad request is returned. If the domain exists and
+// the user belongs to the organization, then a full workspace record is returned;
+// otherwise just the domain and is_available=false is returned. If the domain does not
+// exist and there is no check_availability query param a 404 is returned; otherwise a
+// 200 response is returned with is_available=true.
 func (s *Server) WorkspaceLookup(c *gin.Context) {
 	var (
 		err    error

--- a/pkg/quarterdeck/quarterdeck.go
+++ b/pkg/quarterdeck/quarterdeck.go
@@ -266,6 +266,7 @@ func (s *Server) Routes(router *gin.Engine) (err error) {
 		v1.POST("/authenticate", s.Authenticate)
 		v1.POST("/refresh", s.Refresh)
 		v1.POST("/verify", s.VerifyEmail)
+		v1.POST("/resend", s.ResendEmail)
 
 		// Authenticated access routes
 		v1.POST("/switch", authenticate, s.Switch)


### PR DESCRIPTION
### Scope of changes

Implements a `POST /v1/resend` endpoint that will cause Quarterdeck to resend a verification email if the user has not been verified or a user invitation if the user has not been invited. This endpoint always returns 204.

TODO: should we place some limitation on how many emails can be sent so someone doesn't use this to spam our users?

Fixes SC-21201

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

This endpoint is sufficient for the Resend Email functionality on the front end.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

