### PR TITLE
Add access token back to auth replies

### DIFF
--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -15,14 +15,14 @@ type TenantClient interface {
 	Status(context.Context) (*StatusReply, error)
 
 	Register(context.Context, *RegisterRequest) error
-	Login(context.Context, *LoginRequest) error
-	Refresh(context.Context, *RefreshRequest) error
-	Switch(context.Context, *SwitchRequest) error
+	Login(context.Context, *LoginRequest) (*AuthReply, error)
+	Refresh(context.Context, *RefreshRequest) (*AuthReply, error)
+	Switch(context.Context, *SwitchRequest) (*AuthReply, error)
 	VerifyEmail(context.Context, *VerifyRequest) error
 	ResendEmail(context.Context, *ResendRequest) error
 
 	InvitePreview(context.Context, string) (*MemberInvitePreview, error)
-	InviteAccept(context.Context, *MemberInviteToken) error
+	InviteAccept(context.Context, *MemberInviteToken) (*AuthReply, error)
 
 	OrganizationList(context.Context, *PageQuery) (*OrganizationPage, error)
 	OrganizationDetail(context.Context, string) (*Organization, error)

--- a/pkg/tenant/api/v1/client.go
+++ b/pkg/tenant/api/v1/client.go
@@ -116,40 +116,43 @@ func (s *APIv1) Register(ctx context.Context, in *RegisterRequest) (err error) {
 	return nil
 }
 
-func (s *APIv1) Login(ctx context.Context, in *LoginRequest) (err error) {
+func (s *APIv1) Login(ctx context.Context, in *LoginRequest) (out *AuthReply, err error) {
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/login", in, nil); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.Do(req, nil, true); err != nil {
-		return err
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
 	}
-	return nil
+	return out, nil
 }
 
-func (s *APIv1) Refresh(ctx context.Context, in *RefreshRequest) (err error) {
+func (s *APIv1) Refresh(ctx context.Context, in *RefreshRequest) (out *AuthReply, err error) {
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/refresh", in, nil); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.Do(req, nil, true); err != nil {
-		return err
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
 	}
-	return nil
+	return out, nil
 }
 
-func (s *APIv1) Switch(ctx context.Context, in *SwitchRequest) (err error) {
+func (s *APIv1) Switch(ctx context.Context, in *SwitchRequest) (out *AuthReply, err error) {
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/switch", in, nil); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.Do(req, nil, true); err != nil {
-		return err
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
 	}
-	return nil
+	return out, nil
 }
 
 func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (err error) {
@@ -195,16 +198,17 @@ func (s *APIv1) InvitePreview(ctx context.Context, token string) (out *MemberInv
 	return out, nil
 }
 
-func (s *APIv1) InviteAccept(ctx context.Context, in *MemberInviteToken) (err error) {
+func (s *APIv1) InviteAccept(ctx context.Context, in *MemberInviteToken) (out *AuthReply, err error) {
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/invites/accept", in, nil); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.Do(req, nil, true); err != nil {
-		return err
+	out = &AuthReply{}
+	if _, err = s.Do(req, out, true); err != nil {
+		return nil, err
 	}
-	return nil
+	return out, nil
 }
 
 func (s *APIv1) OrganizationList(ctx context.Context, in *PageQuery) (out *OrganizationPage, err error) {

--- a/pkg/tenant/api/v1/client_test.go
+++ b/pkg/tenant/api/v1/client_test.go
@@ -158,13 +158,19 @@ func TestRegister(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
+	fixture := &api.AuthReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
+
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/login", r.URL.Path)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
 	}))
 	defer ts.Close()
 
@@ -177,18 +183,25 @@ func TestLogin(t *testing.T) {
 		Email:    "leopold.wentzel@gmail.com",
 		Password: "hunter2",
 	}
-	err = client.Login(context.Background(), req)
+	rep, err := client.Login(context.Background(), req)
 	require.NoError(t, err, "could not execute login request")
+	require.Equal(t, fixture, rep, "expected the fixture to be returned")
 }
 
 func TestRefresh(t *testing.T) {
+	fixture := &api.AuthReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
+
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/refresh", r.URL.Path)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
 	}))
 	defer ts.Close()
 
@@ -200,18 +213,25 @@ func TestRefresh(t *testing.T) {
 	req := &api.RefreshRequest{
 		RefreshToken: "refresh",
 	}
-	err = client.Refresh(context.Background(), req)
+	rep, err := client.Refresh(context.Background(), req)
 	require.NoError(t, err, "could not execute refresh request")
+	require.Equal(t, fixture, rep, "expected the fixture to be returned")
 }
 
 func TestSwitch(t *testing.T) {
+	fixture := &api.AuthReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
+
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/switch", r.URL.Path)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
 	}))
 	defer ts.Close()
 
@@ -223,8 +243,9 @@ func TestSwitch(t *testing.T) {
 	req := &api.SwitchRequest{
 		OrgID: "001",
 	}
-	err = client.Switch(context.Background(), req)
+	rep, err := client.Switch(context.Background(), req)
 	require.NoError(t, err, "could not execute switch request")
+	require.Equal(t, fixture, rep, "expected the fixture to be returned")
 }
 
 func TestVerifyEmail(t *testing.T) {
@@ -311,13 +332,19 @@ func TestInvitePreview(t *testing.T) {
 }
 
 func TestInviteAccept(t *testing.T) {
+	fixture := &api.AuthReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
+
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.Equal(t, "/v1/invites/accept", r.URL.Path)
 
 		w.Header().Add("Content-Type", "application/json; charset=utf-8")
-		w.WriteHeader(http.StatusNoContent)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(fixture)
 	}))
 	defer ts.Close()
 
@@ -328,8 +355,9 @@ func TestInviteAccept(t *testing.T) {
 	req := &api.MemberInviteToken{
 		Token: "token",
 	}
-	err = client.InviteAccept(context.Background(), req)
+	rep, err := client.InviteAccept(context.Background(), req)
 	require.NoError(t, err, "could not execute invite accept request")
+	require.Equal(t, fixture, rep, "expected the fixture to be returned")
 }
 
 func TestOrganizationList(t *testing.T) {

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -240,7 +240,12 @@ func (s *Server) Login(c *gin.Context) {
 		return db.UpdateLastLogin(ctx, reply.AccessToken, time.Now())
 	}), tasks.WithError(fmt.Errorf("could not update last login for user after login")))
 
-	c.Status(http.StatusNoContent)
+	out := &api.AuthReply{
+		AccessToken:  reply.AccessToken,
+		RefreshToken: reply.RefreshToken,
+		LastLogin:    reply.LastLogin,
+	}
+	c.JSON(http.StatusOK, out)
 }
 
 // Refresh is a publicly accessible endpoint that allows users to refresh their
@@ -313,7 +318,12 @@ func (s *Server) Refresh(c *gin.Context) {
 		return db.UpdateLastLogin(ctx, reply.AccessToken, time.Now())
 	}), tasks.WithError(fmt.Errorf("could not update last login for user after refresh")))
 
-	c.Status(http.StatusNoContent)
+	out := &api.AuthReply{
+		AccessToken:  reply.AccessToken,
+		RefreshToken: reply.RefreshToken,
+		LastLogin:    reply.LastLogin,
+	}
+	c.JSON(http.StatusOK, out)
 }
 
 // Switch is an authenticated endpoint that allows human users to switch between
@@ -396,7 +406,12 @@ func (s *Server) Switch(c *gin.Context) {
 		return db.UpdateLastLogin(ctx, reply.AccessToken, time.Now())
 	}), tasks.WithError(fmt.Errorf("could not update last login for user after switch")))
 
-	c.Status(http.StatusNoContent)
+	out := &api.AuthReply{
+		AccessToken:  reply.AccessToken,
+		RefreshToken: reply.RefreshToken,
+		LastLogin:    reply.LastLogin,
+	}
+	c.JSON(http.StatusOK, out)
 }
 
 // ProtectLogin prepares the front-end for login by setting the double cookie

--- a/pkg/tenant/auth_test.go
+++ b/pkg/tenant/auth_test.go
@@ -254,57 +254,63 @@ func (s *tenantTestSuite) TestLogin() {
 		Email: "leopold.wentzel@gmail.com",
 		OrgID: orgID.String(),
 	}
-	reply := &qd.LoginReply{}
-	reply.AccessToken, reply.RefreshToken, err = s.quarterdeck.CreateTokenPair(claims)
+	creds := &qd.LoginReply{}
+	creds.AccessToken, creds.RefreshToken, err = s.quarterdeck.CreateTokenPair(claims)
 	require.NoError(err, "could not create token pair from claims fixture")
-	s.quarterdeck.OnLogin(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply))
+	s.quarterdeck.OnLogin(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(creds))
 
 	// Email is required
 	req := &api.LoginRequest{
 		Password: "hunter2",
 	}
 
-	err = s.client.Login(ctx, req)
+	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusBadRequest, responses.ErrTryLoginAgain)
 
 	// Password is required
 	req.Email = "leopold.wentzel@gmail.com"
 	req.Password = ""
-	err = s.client.Login(ctx, req)
+	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusBadRequest, responses.ErrTryLoginAgain)
 
 	// Successful login
 	req.Password = "hunter2"
-	err = s.client.Login(ctx, req)
+	rep, err := s.client.Login(ctx, req)
 	require.NoError(err, "could not complete login")
-	s.requireAuthCookies(reply.AccessToken, reply.RefreshToken)
+	require.Equal(creds.AccessToken, rep.AccessToken, "expected access token to match")
+	require.Equal(creds.RefreshToken, rep.RefreshToken, "expected refresh token to match")
+	s.requireAuthCookies(creds.AccessToken, creds.RefreshToken)
 	s.ClearAuthTokens()
 	s.ResetTasks()
 
 	// Set invite token and test login.
 	req.InviteToken = "pUqQaDxWrqSGZzkxFDYNfCMSMlB9gpcfzorN8DsdjIA"
-	err = s.client.Login(ctx, req)
+	rep, err = s.client.Login(ctx, req)
 	require.NoError(err, "could not complete login")
-	s.requireAuthCookies(reply.AccessToken, reply.RefreshToken)
+	require.Equal(creds.AccessToken, rep.AccessToken, "expected access token to match")
+	require.Equal(creds.RefreshToken, rep.RefreshToken, "expected refresh token to match")
+	s.requireAuthCookies(creds.AccessToken, creds.RefreshToken)
 	s.ClearAuthTokens()
 	s.ResetTasks()
 
 	// Set orgID and return an error if invite token is set.
 	req.OrgID = orgID.String()
-	err = s.client.Login(ctx, req)
+	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusBadRequest, "cannot provide both invite token and org id")
 
 	// Should return an error if org ID is not valid.
 	req.InviteToken = ""
 	req.OrgID = "invalid"
-	err = s.client.Login(ctx, req)
+	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusBadRequest, "invalid org id")
 
 	// Test login with orgID and no invite token.
 	req.OrgID = orgID.String()
-	err = s.client.Login(ctx, req)
+	rep, err = s.client.Login(ctx, req)
 	require.NoError(err, "could not complete login")
-	s.requireAuthCookies(reply.AccessToken, reply.RefreshToken)
+	require.Equal(creds.AccessToken, rep.AccessToken, "expected access token to match")
+	require.Equal(creds.RefreshToken, rep.RefreshToken, "expected refresh token to match")
+	s.requireAuthCookies(creds.AccessToken, creds.RefreshToken)
 	s.ClearAuthTokens()
 	s.ResetTasks()
 
@@ -312,12 +318,12 @@ func (s *tenantTestSuite) TestLogin() {
 
 	// Login method should handle errors from Quarterdeck
 	s.quarterdeck.OnLogin(mock.UseError(http.StatusForbidden, "invalid login credentials"))
-	err = s.client.Login(ctx, req)
+	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusForbidden, "invalid login credentials")
 
 	// Test returning an error with valid org ID when Quarterdeck returns an error.
 	s.quarterdeck.OnLogin(mock.UseError(http.StatusInternalServerError, "could not create valid credentials"))
-	err = s.client.Login(ctx, req)
+	_, err = s.client.Login(ctx, req)
 	s.requireError(err, http.StatusInternalServerError, "could not create valid credentials")
 }
 
@@ -393,33 +399,35 @@ func (s *tenantTestSuite) TestRefresh() {
 		Email: "leopold.wentzel@gmail.com",
 		OrgID: ulids.New().String(),
 	}
-	reply := &qd.LoginReply{}
-	reply.AccessToken, reply.RefreshToken, err = s.quarterdeck.CreateTokenPair(claims)
+	creds := &qd.LoginReply{}
+	creds.AccessToken, creds.RefreshToken, err = s.quarterdeck.CreateTokenPair(claims)
 	require.NoError(err, "could not create token pair from claims fixture")
-	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply))
+	s.quarterdeck.OnRefresh(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(creds))
 
 	// Refresh token is required
 	req := &api.RefreshRequest{}
-	err = s.client.Refresh(ctx, req)
+	_, err = s.client.Refresh(ctx, req)
 	s.requireError(err, http.StatusBadRequest, responses.ErrLogBackIn)
 
 	// Should return an error if the orgID is not parseable
 	req.RefreshToken = "refresh"
 	req.OrgID = "not-a-ulid"
-	err = s.client.Refresh(ctx, req)
+	_, err = s.client.Refresh(ctx, req)
 	s.requireError(err, http.StatusBadRequest, "invalid org_id")
 
 	// Successful refresh
 	req.OrgID = ulids.New().String()
-	err = s.client.Refresh(ctx, req)
+	rep, err := s.client.Refresh(ctx, req)
 	require.NoError(err, "could not complete refresh")
-	s.requireAuthCookies(reply.AccessToken, reply.RefreshToken)
+	require.Equal(creds.AccessToken, rep.AccessToken, "expected access token to match")
+	require.Equal(creds.RefreshToken, rep.RefreshToken, "expected refresh token to match")
+	s.requireAuthCookies(creds.AccessToken, creds.RefreshToken)
 	s.ClearAuthTokens()
 	s.ResetTasks()
 
 	// Refresh method should handle errors from Quarterdeck
 	s.quarterdeck.OnRefresh(mock.UseError(http.StatusUnauthorized, "expired token"))
-	err = s.client.Refresh(ctx, req)
+	_, err = s.client.Refresh(ctx, req)
 	s.requireError(err, http.StatusUnauthorized, "expired token")
 }
 
@@ -495,42 +503,44 @@ func (s *tenantTestSuite) TestSwitch() {
 		Email: "leopold.wentzel@gmail.com",
 		OrgID: ulids.New().String(),
 	}
-	reply := &qd.LoginReply{}
-	reply.AccessToken, reply.RefreshToken, err = s.quarterdeck.CreateTokenPair(claims)
+	creds := &qd.LoginReply{}
+	creds.AccessToken, creds.RefreshToken, err = s.quarterdeck.CreateTokenPair(claims)
 	require.NoError(err, "could not create token pair from claims fixture")
-	s.quarterdeck.OnSwitch(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(reply))
+	s.quarterdeck.OnSwitch(mock.UseStatus(http.StatusOK), mock.UseJSONFixture(creds))
 
 	// Endpoint must be authenticated
 	req := &api.SwitchRequest{}
-	err = s.client.Switch(ctx, req)
+	_, err = s.client.Switch(ctx, req)
 	s.requireError(err, http.StatusUnauthorized, "this endpoint requires authentication", "expected error when user is not authenticated")
 
 	// Should return an error if the orgID is not provided
 	require.NoError(s.SetClientCredentials(claims), "could not set client credentials")
-	err = s.client.Switch(ctx, req)
+	_, err = s.client.Switch(ctx, req)
 	s.requireError(err, http.StatusBadRequest, "missing org_id in request")
 
 	// Should return an error if the orgID is invalid
 	req.OrgID = "not-a-ulid"
-	err = s.client.Switch(ctx, req)
+	_, err = s.client.Switch(ctx, req)
 	s.requireError(err, http.StatusBadRequest, "invalid org_id in request")
 
 	// Should return an error if the user is already authenticated with the org
 	req.OrgID = claims.OrgID
-	err = s.client.Switch(ctx, req)
+	_, err = s.client.Switch(ctx, req)
 	s.requireError(err, http.StatusBadRequest, "already logged in to this organization")
 
 	// Successfully switching to a new organization
 	req.OrgID = "02GMTWFK4XZY597Y128KXQ4ABC"
-	err = s.client.Switch(ctx, req)
+	rep, err := s.client.Switch(ctx, req)
 	require.NoError(err, "expected successful switch")
-	s.requireAuthCookies(reply.AccessToken, reply.RefreshToken)
+	require.Equal(creds.AccessToken, rep.AccessToken, "expected access token to match")
+	require.Equal(creds.RefreshToken, rep.RefreshToken, "expected refresh token to match")
+	s.requireAuthCookies(creds.AccessToken, creds.RefreshToken)
 	s.ClearAuthTokens()
 	s.ResetTasks()
 
 	// Switch method should handle errors from Quarterdeck
 	s.quarterdeck.OnSwitch(mock.UseError(http.StatusForbidden, "invalid credentials"), mock.RequireAuth())
-	err = s.client.Switch(ctx, req)
+	_, err = s.client.Switch(ctx, req)
 	s.requireError(err, http.StatusForbidden, "invalid credentials")
 }
 

--- a/pkg/tenant/invites.go
+++ b/pkg/tenant/invites.go
@@ -144,6 +144,11 @@ func (s *Server) InviteAccept(c *gin.Context) {
 		return
 	}
 
-	// Return 204 response
-	c.Status(http.StatusNoContent)
+	out := &api.AuthReply{
+		AccessToken:  rep.AccessToken,
+		RefreshToken: rep.RefreshToken,
+		LastLogin:    rep.LastLogin,
+	}
+
+	c.JSON(http.StatusOK, out)
 }

--- a/pkg/tenant/tenant_test.go
+++ b/pkg/tenant/tenant_test.go
@@ -334,7 +334,7 @@ func (s *tenantTestSuite) TestRefreshCookies() {
 
 	// Should be no authentication issues on request
 	require.NoError(s.SetClientCSRFProtection())
-	err = s.client.InviteAccept(ctx, &api.MemberInviteToken{})
+	_, err = s.client.InviteAccept(ctx, &api.MemberInviteToken{})
 	s.requireHTTPError(err, http.StatusBadRequest)
 
 	// New tokens should be available in the cookies


### PR DESCRIPTION
### Scope of changes

This adds the access and refresh tokens back to the auth replies for the Tenant endpoints so that the frontend still has access to the permissions in the claims.

Fixes SC-21289

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

[Front-End: add screenshots/videos of changes made]

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

