### PR TITLE
More permissive segment parsing

### DIFF
--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -257,9 +257,9 @@ func (m *Member) Normalize() {
 	m.Name = strings.TrimSpace(m.Name)
 	m.Organization = strings.TrimSpace(m.Organization)
 	m.Workspace = strings.ToLower(strings.TrimSpace(m.Workspace))
-	m.ProfessionSegment = strings.TrimSpace(m.ProfessionSegment)
+	m.ProfessionSegment = strings.ToLower(strings.TrimSpace(m.ProfessionSegment))
 	for i, s := range m.DeveloperSegment {
-		m.DeveloperSegment[i] = strings.TrimSpace(s)
+		m.DeveloperSegment[i] = strings.ToLower(strings.TrimSpace(s))
 	}
 	m.Picture = strings.TrimSpace(m.Picture)
 	m.Role = strings.TrimSpace(m.Role)

--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -88,16 +88,17 @@ func (p ProfessionSegment) String() string {
 // Parse a segment string into a ProfessionSegment, empty string is considered
 // unspecified but not an error.
 func ParseProfessionSegment(segment string) (ProfessionSegment, error) {
+	segment = strings.ToLower(strings.TrimSpace(segment))
 	switch segment {
 	case "":
 		return ProfessionSegmentUnspecified, nil
-	case "Unspecified":
+	case "unspecified":
 		return ProfessionSegmentUnspecified, nil
-	case "Work":
+	case "work":
 		return ProfessionSegmentWork, nil
-	case "Education":
+	case "education":
 		return ProfessionSegmentEducation, nil
-	case "Personal":
+	case "personal":
 		return ProfessionSegmentPersonal, nil
 	default:
 		return ProfessionSegmentUnspecified, ErrProfessionUnknown
@@ -135,24 +136,25 @@ func (d DeveloperSegment) String() string {
 // Parse a segment string into a DeveloperSegment, empty string is considered
 // unspecified but not an error.
 func ParseDeveloperSegment(segment string) (DeveloperSegment, error) {
+	segment = strings.ToLower(strings.TrimSpace(segment))
 	switch segment {
 	case "":
 		return DeveloperSegmentUnspecified, nil
-	case "Unspecified":
+	case "unspecified":
 		return DeveloperSegmentUnspecified, nil
-	case "Something else":
+	case "something else":
 		return DeveloperSegmentSomethingElse, nil
-	case "Application development":
+	case "application development":
 		return DeveloperSegmentApplicationDevelopment, nil
-	case "Data science":
+	case "data science":
 		return DeveloperSegmentDataScience, nil
-	case "Data engineering":
+	case "data engineering":
 		return DeveloperSegmentDataEngineering, nil
-	case "Developer experience":
+	case "developer experience":
 		return DeveloperSegmentDeveloperExperience, nil
-	case "Cybersecurity (blue or purple team)":
+	case "cybersecurity (blue or purple team)":
 		return DeveloperSegmentCybersecurity, nil
-	case "DevOps and observability":
+	case "devops and observability":
 		return DeveloperSegmentDevOps, nil
 	default:
 		return DeveloperSegmentUnspecified, ErrDeveloperUnknown

--- a/pkg/tenant/db/members_test.go
+++ b/pkg/tenant/db/members_test.go
@@ -27,13 +27,28 @@ func TestProfessionSegment(t *testing.T) {
 		require.Equal(t, enum, val, "wrong enum value for %s", segment)
 	}
 
-	// Empty string is unspecified
-	enum, err := db.ParseProfessionSegment("")
-	require.NoError(t, err, "could not parse empty profession segment")
-	require.Equal(t, db.ProfessionSegmentUnspecified, enum, "expected empty profession segment to be unspecified")
+	testCases := []struct {
+		segment string
+		enum    db.ProfessionSegment
+		err     error
+	}{
+		{"", db.ProfessionSegmentUnspecified, nil},
+		{"NotARealSegment", db.ProfessionSegmentUnspecified, db.ErrProfessionUnknown},
+		{" work ", db.ProfessionSegmentWork, nil},
+		{"Work", db.ProfessionSegmentWork, nil},
+		{"WORK", db.ProfessionSegmentWork, nil},
+		{"EduCatIon", db.ProfessionSegmentEducation, nil},
+	}
 
-	_, err = db.ParseProfessionSegment("NotARealSegment")
-	require.ErrorIs(t, err, db.ErrProfessionUnknown, "expected unknown profession segment error")
+	for i, tc := range testCases {
+		enum, err := db.ParseProfessionSegment(tc.segment)
+		if tc.err == nil {
+			require.NoError(t, err, "expected no error for test case: %d", i)
+			require.Equal(t, tc.enum, enum, "wrong enum value for test case: %d", i)
+		} else {
+			require.ErrorIs(t, err, tc.err, "expected error for test case: %d", i)
+		}
+	}
 }
 
 func TestDeveloperSegment(t *testing.T) {
@@ -45,13 +60,27 @@ func TestDeveloperSegment(t *testing.T) {
 		require.Equal(t, enum, val, "wrong enum value for %s", segment)
 	}
 
-	// Empty string is unspecified
-	enum, err := db.ParseDeveloperSegment("")
-	require.NoError(t, err, "could not parse empty developer segment")
-	require.Equal(t, db.DeveloperSegmentUnspecified, enum, "expected empty developer segment to be unspecified")
+	testCases := []struct {
+		segment string
+		enum    db.DeveloperSegment
+		err     error
+	}{
+		{"", db.DeveloperSegmentUnspecified, nil},
+		{"NotARealSegment", db.DeveloperSegmentUnspecified, db.ErrDeveloperUnknown},
+		{"Application Development", db.DeveloperSegmentApplicationDevelopment, nil},
+		{"application development", db.DeveloperSegmentApplicationDevelopment, nil},
+		{" data science ", db.DeveloperSegmentDataScience, nil},
+	}
 
-	_, err = db.ParseDeveloperSegment("NotARealSegment")
-	require.ErrorIs(t, err, db.ErrDeveloperUnknown, "expected unknown developer segment error")
+	for i, tc := range testCases {
+		enum, err := db.ParseDeveloperSegment(tc.segment)
+		if tc.err == nil {
+			require.NoError(t, err, "expected no error for test case: %d", i)
+			require.Equal(t, tc.enum, enum, "wrong enum value for test case: %d", i)
+		} else {
+			require.ErrorIs(t, err, tc.err, "expected error for test case: %d", i)
+		}
+	}
 }
 
 func TestMemberModel(t *testing.T) {


### PR DESCRIPTION
### Scope of changes

This makes the segment parsing in the profile a bit more permissive to make the frontend requests more flexible.

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

[Copy acceptance criteria checklist from story for reviewer, or add a brief acceptance criteria here]

[Front-End: add screenshots/videos of changes made]

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

