### PR TITLE
Revert default organization name

### DIFF
--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -58,7 +58,6 @@ func (s *Server) Register(c *gin.Context) {
 		Email:        params.Email,
 		Password:     params.Password,
 		PwCheck:      params.PwCheck,
-		Organization: params.DefaultOrganization(),
 		AgreeToS:     params.AgreeToS,
 		AgreePrivacy: params.AgreePrivacy,
 	}


### PR DESCRIPTION
### Scope of changes

This reverts the default organization name behavior in Tenant, instead populating the name with whatever Quarterdeck sends back, which is currently nothing.

Fixes SC-21403

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

We don't need a default for the organization name, instead the frontend will handle any weirdness where the name is empty but needs to be displayed to the user.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

