### PR TITLE
Issue claims on verify email

### DIFF
--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -22,7 +22,7 @@ type QuarterdeckClient interface {
 	Authenticate(context.Context, *APIAuthentication) (*LoginReply, error)
 	Refresh(context.Context, *RefreshRequest) (*LoginReply, error)
 	Switch(context.Context, *SwitchRequest) (*LoginReply, error)
-	VerifyEmail(context.Context, *VerifyRequest) error
+	VerifyEmail(context.Context, *VerifyRequest) (*LoginReply, error)
 	ResendEmail(context.Context, *ResendRequest) error
 
 	// Organizations Resource
@@ -173,7 +173,8 @@ type SwitchRequest struct {
 }
 
 type VerifyRequest struct {
-	Token string `json:"token"`
+	Token string    `json:"token"`
+	OrgID ulid.ULID `json:"org_id,omitempty"`
 }
 
 type ResendRequest struct {

--- a/pkg/quarterdeck/api/v1/client.go
+++ b/pkg/quarterdeck/api/v1/client.go
@@ -156,17 +156,17 @@ func (s *APIv1) Switch(ctx context.Context, in *SwitchRequest) (out *LoginReply,
 	return out, nil
 }
 
-func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (err error) {
+func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (out *LoginReply, err error) {
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/verify", in, nil); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.Do(req, nil, true); err != nil {
-		return err
+	if _, err = s.Do(req, &out, true); err != nil {
+		return nil, err
 	}
 
-	return nil
+	return out, nil
 }
 
 func (s *APIv1) ResendEmail(ctx context.Context, in *ResendRequest) (err error) {

--- a/pkg/quarterdeck/api/v1/client_test.go
+++ b/pkg/quarterdeck/api/v1/client_test.go
@@ -276,7 +276,10 @@ func TestSwitch(t *testing.T) {
 
 func TestVerifyEmail(t *testing.T) {
 	// Create a test server with a simple response fixture.
-	fixture := &api.Reply{Success: true}
+	fixture := &api.LoginReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
 	ts := httptest.NewServer(testhandler(fixture, http.MethodPost, "/v1/verify"))
 	defer ts.Close()
 
@@ -285,8 +288,9 @@ func TestVerifyEmail(t *testing.T) {
 	require.NoError(t, err, "could not create api client")
 
 	req := &api.VerifyRequest{Token: "1234567890"}
-	err = client.VerifyEmail(context.TODO(), req)
+	rep, err := client.VerifyEmail(context.TODO(), req)
 	require.NoError(t, err, "could not execute api request")
+	require.Equal(t, fixture, rep, "unexpected response returned")
 }
 
 func TestResendEmail(t *testing.T) {

--- a/pkg/quarterdeck/auth.go
+++ b/pkg/quarterdeck/auth.go
@@ -779,8 +779,9 @@ func (s *Server) Switch(c *gin.Context) {
 
 // VerifyEmail verifies a user's email address by validating the token in the request.
 // This endpoint is intended to be called by frontend applications after the user has
-// followed the link in the verification email. If the token is already verified this
-// endpoint returns a 202 Accepted response.
+// followed the link in the verification email. If the user is not verified and the
+// token is valid then the user is logged in. If the user is already verified then a
+// 204 response is returned.
 func (s *Server) VerifyEmail(c *gin.Context) {
 	var (
 		req *api.VerifyRequest
@@ -801,7 +802,7 @@ func (s *Server) VerifyEmail(c *gin.Context) {
 
 	// Look up the user by the token
 	var user *models.User
-	if user, err = models.GetUserByToken(c, req.Token); err != nil {
+	if user, err = models.GetUserByToken(c, req.Token, req.OrgID); err != nil {
 		if errors.Is(err, models.ErrNotFound) {
 			c.Error(err)
 			c.JSON(http.StatusBadRequest, api.ErrorResponse("invalid token"))
@@ -815,7 +816,7 @@ func (s *Server) VerifyEmail(c *gin.Context) {
 
 	// Return 202 if user is already verified
 	if user.EmailVerified {
-		c.Status(http.StatusAccepted)
+		c.Status(http.StatusNoContent)
 		return
 	}
 
@@ -872,7 +873,25 @@ func (s *Server) VerifyEmail(c *gin.Context) {
 
 	// increment verified users in prometheus
 	metrics.Verified.WithLabelValues(ServiceName).Inc()
-	c.Status(http.StatusNoContent)
+
+	// Issue claims to the user to log them in, this skips the password check so it
+	// only happens the first time a user is verified.
+	var claims *tokens.Claims
+	if claims, err = user.NewClaims(c.Request.Context()); err != nil {
+		sentry.Error(c).Err(err).Msg("could not create claims for user")
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	// Create a new access token/refresh token pair
+	out := &api.LoginReply{}
+	if out.AccessToken, out.RefreshToken, err = s.tokens.CreateTokenPair(claims); err != nil {
+		sentry.Error(c).Err(err).Msg("could not create access and refresh token")
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	c.JSON(http.StatusOK, out)
 }
 
 // ResendEmail accepts an email address via a POST request and always returns a 204

--- a/pkg/quarterdeck/auth_test.go
+++ b/pkg/quarterdeck/auth_test.go
@@ -636,21 +636,21 @@ func (s *quarterdeckTestSuite) TestVerify() {
 	defer mock.Reset()
 
 	// Test that an empty token is rejected
-	err := s.client.VerifyEmail(ctx, &api.VerifyRequest{})
+	_, err := s.client.VerifyEmail(ctx, &api.VerifyRequest{})
 	s.CheckError(err, http.StatusBadRequest, "missing token in request")
 
 	// Test that an error is returned if it doesn't exist in the database
 	req := &api.VerifyRequest{
 		Token: "wrongtoken",
 	}
-	err = s.client.VerifyEmail(ctx, req)
+	_, err = s.client.VerifyEmail(ctx, req)
 	s.CheckError(err, http.StatusBadRequest, "invalid token")
 
 	// Test that 410 is returned if the token is expired
 	// jannel@example.com
 	req.Token = "EpiLbYGb58xsOsjk2CWaNMOS0s-LCyW1VVvKrZNg7dI"
 	sent := time.Now()
-	err = s.client.VerifyEmail(ctx, req)
+	_, err = s.client.VerifyEmail(ctx, req)
 	s.CheckError(err, http.StatusGone, "token expired, a new verification token has been sent to the email associated with the account")
 
 	// User should be issued a new token
@@ -667,8 +667,18 @@ func (s *quarterdeckTestSuite) TestVerify() {
 
 	// Happy path - verifying the user
 	req.Token = token
-	err = s.client.VerifyEmail(ctx, req)
+	rep, err := s.client.VerifyEmail(ctx, req)
 	require.NoError(err, "could not verify user")
+	require.NotEmpty(rep.AccessToken, "missing access token")
+	require.NotEmpty(rep.RefreshToken, "missing refresh token")
+
+	// User's organization should be in the claims
+	claims, err := tokens.ParseUnverifiedTokenClaims(rep.AccessToken)
+	require.NoError(err, "could not parse access token")
+	require.Equal("01GKHJSK7CZW0W282ZN3E9W86Z", claims.Subject)
+	require.Equal("01GKHJRF01YXHZ51YMMKV3RCMK", claims.OrgID)
+
+	// TODO: Test loading the user into a different org with orgID in the request
 
 	// User should be verified
 	user, err = models.GetUser(ctx, "01GKHJSK7CZW0W282ZN3E9W86Z", "01GKHJRF01YXHZ51YMMKV3RCMK")
@@ -676,8 +686,9 @@ func (s *quarterdeckTestSuite) TestVerify() {
 	require.True(user.EmailVerified, "user should be verified")
 
 	// Test that 202 is returned if the user is already verified
-	err = s.client.VerifyEmail(ctx, req)
+	rep, err = s.client.VerifyEmail(ctx, req)
 	require.NoError(err, "expected no error when user is already verified")
+	require.Nil(rep, "expected no login credentials when user is already verified")
 
 	// Test that the verification email was sent for the expired case
 	s.StopTasks()

--- a/pkg/quarterdeck/db/models/users.go
+++ b/pkg/quarterdeck/db/models/users.go
@@ -166,10 +166,15 @@ func GetUserEmail(ctx context.Context, email string, orgID any) (u *User, err er
 }
 
 // GetUser by verification token by executing a read-only transaction against the
-// database.
-func GetUserByToken(ctx context.Context, token string) (u *User, err error) {
+// database. If an orgID is specified then the user is loaded in that organization.
+func GetUserByToken(ctx context.Context, token string, orgID any) (u *User, err error) {
 	u = &User{
 		EmailVerificationToken: sql.NullString{String: token, Valid: true},
+	}
+
+	var userOrg ulid.ULID
+	if userOrg, err = ulids.Parse(orgID); err != nil {
+		return nil, err
 	}
 
 	var tx *sql.Tx
@@ -182,6 +187,11 @@ func GetUserByToken(ctx context.Context, token string) (u *User, err error) {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
 		}
+		return nil, err
+	}
+
+	// Load the user in the specified organization or their default organization
+	if err = u.loadOrganization(tx, userOrg); err != nil {
 		return nil, err
 	}
 

--- a/pkg/tenant/api/v1/api.go
+++ b/pkg/tenant/api/v1/api.go
@@ -18,7 +18,7 @@ type TenantClient interface {
 	Login(context.Context, *LoginRequest) (*AuthReply, error)
 	Refresh(context.Context, *RefreshRequest) (*AuthReply, error)
 	Switch(context.Context, *SwitchRequest) (*AuthReply, error)
-	VerifyEmail(context.Context, *VerifyRequest) error
+	VerifyEmail(context.Context, *VerifyRequest) (*AuthReply, error)
 	ResendEmail(context.Context, *ResendRequest) error
 
 	InvitePreview(context.Context, string) (*MemberInvitePreview, error)
@@ -173,6 +173,7 @@ type SwitchRequest struct {
 
 type VerifyRequest struct {
 	Token string `json:"token"`
+	OrgID string `json:"org_id,omitempty"`
 }
 
 type ResendRequest struct {

--- a/pkg/tenant/api/v1/client.go
+++ b/pkg/tenant/api/v1/client.go
@@ -155,16 +155,16 @@ func (s *APIv1) Switch(ctx context.Context, in *SwitchRequest) (out *AuthReply, 
 	return out, nil
 }
 
-func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (err error) {
+func (s *APIv1) VerifyEmail(ctx context.Context, in *VerifyRequest) (out *AuthReply, err error) {
 	var req *http.Request
 	if req, err = s.NewRequest(ctx, http.MethodPost, "/v1/verify", in, nil); err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = s.Do(req, nil, true); err != nil {
-		return err
+	if _, err = s.Do(req, &out, true); err != nil {
+		return nil, err
 	}
-	return nil
+	return out, nil
 }
 
 func (s *APIv1) ResendEmail(ctx context.Context, in *ResendRequest) (err error) {

--- a/pkg/tenant/api/v1/client_test.go
+++ b/pkg/tenant/api/v1/client_test.go
@@ -249,7 +249,10 @@ func TestSwitch(t *testing.T) {
 }
 
 func TestVerifyEmail(t *testing.T) {
-	fixture := &api.Reply{}
+	fixture := &api.AuthReply{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+	}
 
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -270,8 +273,9 @@ func TestVerifyEmail(t *testing.T) {
 	req := &api.VerifyRequest{
 		Token: "token",
 	}
-	err = client.VerifyEmail(context.Background(), req)
+	rep, err := client.VerifyEmail(context.Background(), req)
 	require.NoError(t, err, "could not execute verify request")
+	require.Equal(t, fixture, rep, "expected the fixture to be returned")
 }
 
 func TestResendEmail(t *testing.T) {


### PR DESCRIPTION
### Scope of changes

This updates the verify email endpoints so that they return claims to the user and set credentials in the cookies if the user has not been verified yet. If the user has been verified, no credentials are returned to avoid circumventing the Login endpoint.

Fixes SC-21484

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

The verify email endpoints should login the user including setting the cookies.
If the user is already verified don't login the user, this will ensure that VerifyEmail can only login the user once and after that they need to use their credentials or the refresh token

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

