### PR TITLE
Default profession and developer segments

### DIFF
--- a/pkg/tenant/db/members.go
+++ b/pkg/tenant/db/members.go
@@ -81,6 +81,10 @@ var ProfessionSegmentStrings = map[ProfessionSegment]string{
 	ProfessionSegmentPersonal:    "Personal",
 }
 
+func (p ProfessionSegment) IsZero() bool {
+	return p == ProfessionSegmentUnspecified
+}
+
 func (p ProfessionSegment) String() string {
 	return ProfessionSegmentStrings[p]
 }
@@ -267,7 +271,7 @@ func (m *Member) OnboardingStatus() MemberStatus {
 // IsOnboarded returns true if there is enough information to consider the member fully
 // onboarded into the organization.
 func (m *Member) IsOnboarded() bool {
-	return m.Name != "" && m.Organization != "" && m.Workspace != "" && m.ProfessionSegment != ProfessionSegmentUnspecified && len(m.DeveloperSegment) > 0
+	return m.Name != "" && m.Organization != "" && m.Workspace != "" && !m.ProfessionSegment.IsZero() && len(m.DeveloperSegment) > 0
 }
 
 func (m *Member) Picture() string {

--- a/pkg/tenant/members.go
+++ b/pkg/tenant/members.go
@@ -173,6 +173,18 @@ func (s *Server) MemberCreate(c *gin.Context) {
 		Invited:      true,
 	}
 
+	if dbMember.Name != "" {
+		// If the user already has a name then ensure they do not have to complete
+		// onboarding again for the new organization.
+		if dbMember.ProfessionSegment.IsZero() {
+			dbMember.ProfessionSegment = db.ProfessionSegmentWork
+		}
+
+		if len(dbMember.DeveloperSegment) == 0 {
+			dbMember.DeveloperSegment = []db.DeveloperSegment{db.DeveloperSegmentSomethingElse}
+		}
+	}
+
 	if err = db.CreateMember(c.Request.Context(), dbMember); err != nil {
 		sentry.Error(c).Err(err).Msg("could not create member in database after invitation")
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse("could not add team member"))

--- a/pkg/tenant/members_test.go
+++ b/pkg/tenant/members_test.go
@@ -297,12 +297,11 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 	_, err = suite.client.MemberCreate(ctx, &api.Member{Email: "test@testing.com", Role: "invalid"})
 	suite.requireError(err, http.StatusBadRequest, "unknown member role", "expected error when member role is invalid")
 
-	// Create a member test fixture
+	// Successfully invite a new member.
 	req := &api.Member{
 		Role:  role,
 		Email: email,
 	}
-
 	rep, err := suite.client.MemberCreate(ctx, req)
 	require.NoError(err, "could not add member")
 	require.NotEmpty(rep.ID, "expected non-zero ulid to be populated")
@@ -311,6 +310,8 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 	require.Equal(req.Role, rep.Role, "expected member role to match")
 	require.NotEmpty(rep.Organization, "expected organization to be populated")
 	require.NotEmpty(rep.Workspace, "expected workspace to be populated")
+	require.Equal(db.ProfessionSegmentUnspecified.String(), rep.ProfessionSegment, "expected profession segment to be unspecified")
+	require.Empty(rep.DeveloperSegment, "expected developer segment to be empty")
 	require.True(rep.Invited, "expected member to have the invited flag set")
 	require.Equal(rep.OnboardingStatus, db.MemberStatusPending.String(), "expected member status to be pending")
 	require.NotEmpty(rep.Created, "expected created time to be populated")
@@ -323,6 +324,15 @@ func (suite *tenantTestSuite) TestMemberCreate() {
 
 	_, err = suite.client.MemberCreate(ctx, req)
 	suite.requireError(err, http.StatusBadRequest, "team member already exists with this email address", "expected error when member email already exists")
+
+	// Test that existing users have the profession and developer segments set
+	invite.Name = "Leopold Wentzel"
+	suite.quarterdeck.OnInvitesCreate(mock.UseJSONFixture(invite), mock.RequireAuth())
+	req.Email = "leopold.wentzel2@gmail.com"
+	rep, err = suite.client.MemberCreate(ctx, req)
+	require.NoError(err, "could not invite member")
+	require.NotEmpty(rep.ProfessionSegment, "expected profession segment to be populated")
+	require.NotEmpty(rep.DeveloperSegment, "expected developer segment to be populated")
 
 	// Test that the endpoint returns an error if quarterdeck returns an error.
 	suite.quarterdeck.OnInvitesCreate(mock.UseError(http.StatusUnauthorized, "invalid user claims"))


### PR DESCRIPTION
### Scope of changes

This populates the profession and developer segments for invited users so that they do not have to go through the onboarding process for each organization they join, but only if they onboarded previously.

Fixes SC-21667

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

If I'm an invited user with an Ensign account I don't need to go through onboarding again. The backend should set default values for onboarding fields when the member record for an invited user is created, but we only want to do this if they've already completed onboarding for an organization.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [ x Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

