### PR TITLE
Add unverified flag to login response

### DIFF
--- a/pkg/quarterdeck/api/v1/api.go
+++ b/pkg/quarterdeck/api/v1/api.go
@@ -71,8 +71,9 @@ type QuarterdeckClient interface {
 
 // Reply contains standard fields that are used for generic API responses and errors.
 type Reply struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
+	Success    bool   `json:"success"`
+	Error      string `json:"error,omitempty"`
+	Unverified bool   `json:"unverified,omitempty"`
 }
 
 // Returned on status requests.

--- a/pkg/quarterdeck/api/v1/errors.go
+++ b/pkg/quarterdeck/api/v1/errors.go
@@ -8,12 +8,14 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rotationalio/ensign/pkg/utils/responses"
 )
 
 var (
 	unsuccessful = Reply{Success: false}
 	notFound     = Reply{Success: false, Error: "resource not found"}
 	notAllowed   = Reply{Success: false, Error: "method not allowed"}
+	unverified   = Reply{Success: false, Unverified: true, Error: responses.ErrVerifyEmail}
 )
 
 var (
@@ -71,6 +73,12 @@ func NotFound(c *gin.Context) {
 // NotAllowed returns a JSON 405 response for the API.
 func NotAllowed(c *gin.Context) {
 	c.JSON(http.StatusMethodNotAllowed, notAllowed)
+}
+
+// Unverified returns a JSON 403 response indicating that the user has not verified
+// their email address.
+func Unverified(c *gin.Context) {
+	c.JSON(http.StatusForbidden, unverified)
 }
 
 // FieldError provides a general mechanism for specifying errors with specific API

--- a/pkg/quarterdeck/auth.go
+++ b/pkg/quarterdeck/auth.go
@@ -247,7 +247,7 @@ func (s *Server) Login(c *gin.Context) {
 	// User must be verified to log in.
 	if !user.EmailVerified {
 		log.Debug().Msg("user has not verified their email address")
-		c.JSON(http.StatusForbidden, api.ErrorResponse(responses.ErrVerifyEmail))
+		api.Unverified(c)
 
 		// increment failure count
 		metrics.FailedLogins.WithLabelValues(ServiceName, UserHuman, "unverified email").Inc()


### PR DESCRIPTION
### Scope of changes

This adds an `unverified` flag to the Login response if the user is unverified, so the frontend can properly distinguish between credential errors and not verified errors.

Fixes SC-21669

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

On not verified errors, the frontend would like a flag returned to know whether or not to display the resend email option to the user.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

