### PR TITLE
Set CSRF tokens in verify email

### DIFF
--- a/pkg/tenant/api/v1/errors.go
+++ b/pkg/tenant/api/v1/errors.go
@@ -36,6 +36,8 @@ var (
 	ErrNoCookies              = errors.New("no cookies available")
 	ErrNoRefreshToken         = errors.New("refresh token not found in cookies")
 	ErrNoAccessToken          = errors.New("access token not found in cookies")
+	ErrNoCSRFToken            = errors.New("csrf token not found in cookies")
+	ErrNoCSRFReferenceToken   = errors.New("csrf reference token not found in cookies")
 )
 
 // FieldValidationError represents a validation error for a specific field, when the

--- a/pkg/tenant/auth.go
+++ b/pkg/tenant/auth.go
@@ -479,6 +479,12 @@ func (s *Server) VerifyEmail(c *gin.Context) {
 			return
 		}
 
+		if err = middleware.SetDoubleCookieToken(c, s.conf.Auth.CookieDomain, time.Now().Add(authCSRFLifetime)); err != nil {
+			sentry.Error(c).Err(err).Msg("could not set csrf protection cookies")
+			c.Status(http.StatusNoContent)
+			return
+		}
+
 		// Return the credentials in the reply
 		out := &api.AuthReply{
 			AccessToken:  rep.AccessToken,

--- a/pkg/tenant/auth_test.go
+++ b/pkg/tenant/auth_test.go
@@ -579,6 +579,7 @@ func (s *tenantTestSuite) TestVerifyEmail() {
 		require.Equal(creds.AccessToken, rep.AccessToken, "expected access token to match")
 		require.Equal(creds.RefreshToken, rep.RefreshToken, "expected refresh token to match")
 		s.requireAuthCookies(creds.AccessToken, creds.RefreshToken)
+		s.requireCSRFCookies()
 	})
 
 	s.Run("Already Verified", func() {

--- a/pkg/tenant/tenant_test.go
+++ b/pkg/tenant/tenant_test.go
@@ -323,6 +323,16 @@ func (s *tenantTestSuite) requireNoAuthCookies() {
 	require.ErrorIs(err, api.ErrNoRefreshToken, "expected no refresh token in cookies")
 }
 
+// Asserts that the CSRF tokens were set in the cookies by checking the client's cookie
+// jar.
+func (s *tenantTestSuite) requireCSRFCookies() {
+	require := s.Require()
+	token, referenceToken, err := s.client.(*api.APIv1).GetCSRFTokens()
+	require.NoError(err, "could not get CSRF token from client")
+	require.NotEmpty(token, "expected CSRF token in cookies")
+	require.NotEmpty(referenceToken, "expected CSRF reference token in cookies")
+}
+
 func (s *tenantTestSuite) TestRefreshCookies() {
 	// This test asserts that the Authenticate middleware is properly configured to
 	// automatically refresh the access token when it expires.


### PR DESCRIPTION
### Scope of changes

This adds the CSRF tokens to the cookies if the user is logged in after verifying their email address to ensure the frontend has the CSRF cookie for subsequent Tenant requests.

Fixes SC-21715

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

The backend needs to set the CSRF tokens for the frontend if claims were issued to the user.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

