### PR TITLE
Create Bloom Filter from Event Hashes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rotationalio/ensign
 go 1.20
 
 require (
+	github.com/bits-and-blooms/bloom/v3 v3.6.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/getsentry/sentry-go v0.24.1
 	github.com/gin-contrib/cors v1.4.0
@@ -43,6 +44,7 @@ require (
 	github.com/PuerkitoBio/rehttp v1.2.0 // indirect
 	github.com/auth0/go-auth0 v0.17.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/bytedance/sonic v1.10.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20230717121745-296ad89f973d // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.10.0 h1:ePXTeiPEazB5+opbv5fr8umg2R/1NlzgDsyepwsSr88=
+github.com/bits-and-blooms/bitset v1.10.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
+github.com/bits-and-blooms/bloom/v3 v3.6.0 h1:dTU0OVLJSoOhz9m68FTXMFfA39nR8U/nTCs1zb26mOI=
+github.com/bits-and-blooms/bloom/v3 v3.6.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iHb1kOL2tfHTgyJBHg=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.10.0-rc/go.mod h1:ElCzW+ufi8qKqNW0FY314xriJhyJhuoJ3gFZdAHF7NM=
 github.com/bytedance/sonic v1.10.1 h1:7a1wuFXL1cMy7a3f7/VFcEtriuXQnUBhtoVfOZiaysc=
@@ -236,6 +240,7 @@ github.com/trisacrypto/trisa v0.4.0 h1:0CiKrNR6slc89iYDzr9dy8lZc3LQwMfuaYy/yh4ek
 github.com/trisacrypto/trisa v0.4.0/go.mod h1:19zOnzpbCs96GEyryN91Tw77dhjHNmpNlGB3bRCeB04=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
+github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=

--- a/pkg/ensign/api/v1beta1/errors.go
+++ b/pkg/ensign/api/v1beta1/errors.go
@@ -5,8 +5,10 @@ import "errors"
 // Statically defined errors for error checking the type of error returned by a method
 // or function in the api package.
 var (
-	ErrNoEvent   = errors.New("event wrapper contains no event")
-	ErrNoKeys    = errors.New("no keys specified for key based hashing")
-	ErrNoFields  = errors.New("no fields specified for field based hashing")
-	ErrNoGroupID = errors.New("consumer group requires either id or name")
+	ErrNoEvent          = errors.New("event wrapper contains no event")
+	ErrNoKeys           = errors.New("no keys specified for key based hashing")
+	ErrNoFields         = errors.New("no fields specified for field based hashing")
+	ErrKeysNotAllowed   = errors.New("do not specify keys for this policy")
+	ErrFieldsNotAllowed = errors.New("do not specify fields for this policy")
+	ErrNoGroupID        = errors.New("consumer group requires either id or name")
 )

--- a/pkg/ensign/duplicates.go
+++ b/pkg/ensign/duplicates.go
@@ -1,15 +1,13 @@
 package ensign
 
 import (
+	"bytes"
 	"context"
-	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/cenkalti/backoff/v4"
 	"github.com/oklog/ulid/v2"
 	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/rlid"
-	"github.com/rotationalio/ensign/pkg/utils/radish"
 )
 
 const (
@@ -17,6 +15,11 @@ const (
 	filterMinSize uint = 10000
 )
 
+// TopicFilter loads a bloom filter with all of the event hashes for the events in the
+// specified topic. The TopicInfo for the event is read to determine how many events are
+// in the topic. The bloom filter is constructed as the larger of either 10k events or
+// twice the number of events in the topic and with a false positive rate of 1%. The
+// filter can be tested and modified as needed to detect duplicates.
 func (s *Server) TopicFilter(topicID ulid.ULID) (_ *bloom.BloomFilter, err error) {
 	// Load the topic info to determine the bloom filter size.
 	var info *api.TopicInfo
@@ -52,12 +55,42 @@ func (s *Server) TopicFilter(topicID ulid.ULID) (_ *bloom.BloomFilter, err error
 	return filter, nil
 }
 
-func (s *Server) Rehash(ctx context.Context, topicID ulid.ULID, policy *api.Deduplication) error {
-	// TODO: clear old hashes from the database.
+// Rehash clears the old event hashes and recomputes the hashes with the new policy.
+// TODO: this method operates on a snapshot of the database and is not concurrency safe.
+func (s *Server) Rehash(ctx context.Context, topicID ulid.ULID, policy *api.Deduplication) (err error) {
+	// Clear old hashes from the database.
+	if err = s.data.ClearIndash(topicID); err != nil {
+		return err
+	}
 
+	// Load topic info to build bloom filter
+	// Will return not found if there is no associated topic.
+	var info *api.TopicInfo
+	if info, err = s.meta.TopicInfo(topicID); err != nil {
+		return err
+	}
+
+	// Build the bloom filter for deduplication
+	filter := bloom.NewWithEstimates(uint(info.Events), filterFPRate)
+
+	// Reset the topicInfo duplicate counts now that we've created the filter
+	// NOTE: the next time the topic info gatherer is run, it will seek to the event ID
+	// specified by this topic info so the count and sizes should not change.
+	info.Duplicates = 0
+	for _, etype := range info.Types {
+		etype.Duplicates = 0
+	}
+
+	// Respect context cancellation before moving into iteration
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+
+	// Iterate over all of the events in the database and re-compute hashes.
 	iter := s.data.List(topicID)
 	defer iter.Release()
 
+deduplication:
 	for iter.Next() {
 		// Respect context cancellation and deadlines
 		if err := ctx.Err(); err != nil {
@@ -69,26 +102,47 @@ func (s *Server) Rehash(ctx context.Context, topicID ulid.ULID, policy *api.Dedu
 			return err
 		}
 
+		// If we've reached the end of the events specified by the topic info snapshot
+		// then stop looping otherwise we may inject a consistency issue
+		if bytes.Equal(event.Id, info.EventOffsetId) {
+			break deduplication
+		}
+
+		// Compute the hash of the event given the deduplication policy
 		hash, err := event.Hash(policy)
 		if err != nil {
 			return err
 		}
 
-		// TODO: check if the hash is a duplicate of another event already.
+		// Check if the event is a duplicate of another event already
+		if filter.TestOrAdd(hash) {
+			// TODO: load the duplicate, verify that it is a duplicate
+			// TODO: mark the event as a duplicate and save back to database
+
+			// Update the duplicate counts on the topic info
+			info.Duplicates++
+			if e, err := event.Unwrap(); err == nil {
+				etype := info.FindEventTypeInfo(e.ResolveType(), e.Mimetype)
+				etype.Duplicates++
+			}
+
+			// NOTE: do not continue with the loop to ensure we don't overwrite the index.
+			continue deduplication
+		}
+
+		// If the topic is not a duplicate store the hash in the database.
 		if err := s.data.Indash(topicID, hash, rlid.RLID(event.Id)); err != nil {
 			return err
 		}
 	}
 
-	return iter.Error()
-}
+	if err = iter.Error(); err != nil {
+		return err
+	}
 
-func (s *Server) QueueRehash(topicID ulid.ULID, policy *api.Deduplication) {
-	s.tasks.Queue(radish.TaskFunc(func(ctx context.Context) error {
-		return s.Rehash(ctx, topicID, policy)
-	}), radish.WithErrorf("could not complete rehash of %s", topicID),
-		radish.WithRetries(1),
-		radish.WithBackoff(backoff.NewConstantBackOff(1*time.Minute)),
-		radish.WithTimeout(30*time.Minute),
-	)
+	// Save the topic info back to disk so that it can be carried on later.
+	if err = s.meta.UpdateTopicInfo(info); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/ensign/duplicates.go
+++ b/pkg/ensign/duplicates.go
@@ -2,14 +2,59 @@ package ensign
 
 import (
 	"context"
+	"time"
 
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/oklog/ulid/v2"
 	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/rlid"
 	"github.com/rotationalio/ensign/pkg/utils/radish"
 )
 
+const (
+	filterFPRate       = 0.01
+	filterMinSize uint = 10000
+)
+
+func (s *Server) TopicFilter(topicID ulid.ULID) (_ *bloom.BloomFilter, err error) {
+	// Load the topic info to determine the bloom filter size.
+	var info *api.TopicInfo
+	if info, err = s.meta.TopicInfo(topicID); err != nil {
+		return nil, err
+	}
+
+	// The filter size should be the larger of twice the number of events in the topic
+	// or the minimum filter size (10k hashes by default).
+	filterSize := filterMinSize
+	if uint(info.Events*2) > filterSize {
+		filterSize = uint(info.Events * 2)
+	}
+
+	// Create the bloom filter with index hashes from the database.
+	filter := bloom.NewWithEstimates(filterSize, filterFPRate)
+	iter := s.data.LoadIndash(topicID)
+	defer iter.Release()
+
+	for iter.Next() {
+		var hash []byte
+		if hash, err = iter.Hash(); err != nil {
+			// NOTE: we are not skipping bad hashes because this would make it possible
+			// to miss duplicates -- however, it would be possible to relax this.
+			return nil, err
+		}
+		filter.Add(hash)
+	}
+
+	if err = iter.Error(); err != nil {
+		return nil, err
+	}
+	return filter, nil
+}
+
 func (s *Server) Rehash(ctx context.Context, topicID ulid.ULID, policy *api.Deduplication) error {
+	// TODO: clear old hashes from the database.
+
 	iter := s.data.List(topicID)
 	defer iter.Release()
 
@@ -41,5 +86,9 @@ func (s *Server) Rehash(ctx context.Context, topicID ulid.ULID, policy *api.Dedu
 func (s *Server) QueueRehash(topicID ulid.ULID, policy *api.Deduplication) {
 	s.tasks.Queue(radish.TaskFunc(func(ctx context.Context) error {
 		return s.Rehash(ctx, topicID, policy)
-	}))
+	}), radish.WithErrorf("could not complete rehash of %s", topicID),
+		radish.WithRetries(1),
+		radish.WithBackoff(backoff.NewConstantBackOff(1*time.Minute)),
+		radish.WithTimeout(30*time.Minute),
+	)
 }

--- a/pkg/ensign/duplicates_test.go
+++ b/pkg/ensign/duplicates_test.go
@@ -1,0 +1,100 @@
+package ensign_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/oklog/ulid/v2"
+	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
+	"github.com/rotationalio/ensign/pkg/ensign/store/errors"
+	"github.com/rotationalio/ensign/pkg/ensign/store/iterator"
+	store "github.com/rotationalio/ensign/pkg/ensign/store/mock"
+)
+
+func (s *serverTestSuite) TestTopicFilter() {
+	require := s.Require()
+
+	s.Run("Notfound", func() {
+		s.store.UseError(store.TopicInfo, errors.ErrNotFound)
+		_, err := s.srv.TopicFilter(ulid.MustParse("01HCZHJ1DP6W0WVQHXXRHVAMSH"))
+		require.ErrorIs(err, errors.ErrNotFound)
+	})
+
+	s.Run("Empty", func() {
+		s.store.OnTopicInfo = func(u ulid.ULID) (*api.TopicInfo, error) {
+			return &api.TopicInfo{TopicId: u.Bytes(), Events: 0}, nil
+		}
+		s.store.OnLoadIndash = func(u ulid.ULID) iterator.IndashIterator {
+			return store.NewIndashIterator(nil)
+		}
+
+		filter, err := s.srv.TopicFilter(ulid.MustParse("01HCZHJ1DP6W0WVQHXXRHVAMSH"))
+		require.NoError(err, "expected filter to be returned")
+
+		m, k := bloom.EstimateParameters(10000, 0.01)
+		require.Equal(m, filter.Cap())
+		require.Equal(k, filter.K())
+	})
+
+	s.Run("Small", func() {
+		hashes := make([][]byte, 0, 5000)
+		for i := 0; i < 5000; i++ {
+			hash := make([]byte, 16)
+			_, err := rand.Read(hash)
+			require.NoError(err, "could not create random hash")
+			hashes = append(hashes, hash)
+		}
+
+		s.store.OnTopicInfo = func(u ulid.ULID) (*api.TopicInfo, error) {
+			return &api.TopicInfo{TopicId: u.Bytes(), Events: uint64(len(hashes))}, nil
+		}
+		s.store.OnLoadIndash = func(u ulid.ULID) iterator.IndashIterator {
+			return store.NewIndashIterator(hashes)
+		}
+
+		filter, err := s.srv.TopicFilter(ulid.MustParse("01HCZHJ1DP6W0WVQHXXRHVAMSH"))
+		require.NoError(err, "expected filter to be returned")
+
+		m, k := bloom.EstimateParameters(10000, 0.01)
+		require.Equal(m, filter.Cap())
+		require.Equal(k, filter.K())
+
+		for _, hash := range hashes {
+			require.True(filter.Test(hash))
+		}
+	})
+
+	s.Run("Large", func() {
+		if testing.Short() {
+			s.T().Skip("skipping large topic filter test")
+			return
+		}
+
+		hashes := make([][]byte, 0, 50000)
+		for i := 0; i < 50000; i++ {
+			hash := make([]byte, 16)
+			_, err := rand.Read(hash)
+			require.NoError(err, "could not create random hash")
+			hashes = append(hashes, hash)
+		}
+
+		s.store.OnTopicInfo = func(u ulid.ULID) (*api.TopicInfo, error) {
+			return &api.TopicInfo{TopicId: u.Bytes(), Events: uint64(len(hashes))}, nil
+		}
+		s.store.OnLoadIndash = func(u ulid.ULID) iterator.IndashIterator {
+			return store.NewIndashIterator(hashes)
+		}
+
+		filter, err := s.srv.TopicFilter(ulid.MustParse("01HCZHJ1DP6W0WVQHXXRHVAMSH"))
+		require.NoError(err, "expected filter to be returned")
+
+		m, k := bloom.EstimateParameters(100000, 0.01)
+		require.Equal(m, filter.Cap())
+		require.Equal(k, filter.K())
+
+		for _, hash := range hashes {
+			require.True(filter.Test(hash))
+		}
+	})
+}

--- a/pkg/ensign/store/store.go
+++ b/pkg/ensign/store/store.go
@@ -63,6 +63,7 @@ type EventHashStore interface {
 	// Indash is a combination of "Index" and "Hash"
 	Indash(topicID ulid.ULID, hash []byte, eventID rlid.RLID) error
 	LoadIndash(topicID ulid.ULID) iterator.IndashIterator
+	ClearIndash(topicID ulid.ULID) error
 }
 
 type MetaStore interface {

--- a/pkg/ensign/topics.go
+++ b/pkg/ensign/topics.go
@@ -3,14 +3,18 @@ package ensign
 import (
 	"context"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/oklog/ulid/v2"
 	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
 	"github.com/rotationalio/ensign/pkg/ensign/contexts"
 	"github.com/rotationalio/ensign/pkg/ensign/store/errors"
 	"github.com/rotationalio/ensign/pkg/quarterdeck/permissions"
+	"github.com/rotationalio/ensign/pkg/utils/radish"
 	"github.com/rotationalio/ensign/pkg/utils/sentry"
 	"github.com/rotationalio/ensign/pkg/utils/ulids"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -350,12 +354,49 @@ func (s *Server) SetTopicPolicy(ctx context.Context, in *api.TopicPolicy) (out *
 		return &api.TopicStatus{Id: topicID.String(), State: topic.Status}, nil
 	}
 
-	// Handle any changes to the deduplication strategy of the topic
-	// TODO: normalize/validate incoming policy
-	// TODO: update the policy of the topic
+	// Validate the deduplication policy
+	if err = in.DeduplicationPolicy.Validate(); err != nil {
+		log.Debug().Err(err).Msg("invalid deduplication policy")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	// Update the topic with the new policy
+	policy := in.DeduplicationPolicy.Normalize()
+	topic.Deduplication = policy
+	topic.Status = api.TopicState_PENDING
+
+	if err = s.meta.UpdateTopic(topic); err != nil {
+		sentry.Error(ctx).Err(err).Msg("could not update topic with policy")
+		return nil, status.Error(codes.Internal, "could not process set topic policy request")
+	}
+
 	// TODO: Update the broker with the new policy
-	// TODO: create a job to update the topic's policy
-	return nil, status.Error(codes.Unimplemented, "changing deduplication policies is coming soon!")
+
+	// Update duplicates in the topic info and rehash the events.
+	s.tasks.Queue(radish.TaskFunc(func(ctx context.Context) error {
+		// Rehash the topic
+		if err := s.Rehash(ctx, topicID, topic.Deduplication); err != nil {
+			return err
+		}
+
+		// Mark the topic as ready again
+		topic, err := s.meta.RetrieveTopic(topicID)
+		if err != nil {
+			return err
+		}
+
+		topic.Status = api.TopicState_READY
+		if err := s.meta.UpdateTopic(topic); err != nil {
+			return err
+		}
+		return nil
+	}), radish.WithErrorf("could not complete rehash of %s", topicID),
+		radish.WithRetries(1),
+		radish.WithBackoff(backoff.NewConstantBackOff(5*time.Minute)),
+		radish.WithTimeout(30*time.Minute),
+	)
+
+	return &api.TopicStatus{Id: topicID.String(), State: topic.Status}, nil
 }
 
 // TopicNames returns a paginated response that maps topic names to IDs for all topics


### PR DESCRIPTION
### Scope of changes

Adds a mechanism to create a bloom filter from event hashes for duplicate detection. Uses the [github.com/bits-and-blooms/bloom](https://github.com/bits-and-blooms/bloom) bloom filter library.

Fixes SC-20997

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Create a mechanism to load a bloom filter from event hashes on disk.

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] ~I have recompiled and included new protocol buffers to reflect changes I made if necessary~
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] ~Front-end: Checked sm, md, lg screen resolutions for effective responsiveness~
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] ~Front-end: I've reviewed the Figma design and confirmed that changes match the spec.~
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

