### PR TITLE
Less verbose Sentry errors and fix User IP address

### DIFF
--- a/pkg/ensign/interceptors/auth.go
+++ b/pkg/ensign/interceptors/auth.go
@@ -2,6 +2,7 @@ package interceptors
 
 import (
 	"context"
+	"net"
 	"strings"
 
 	"github.com/getsentry/sentry-go"
@@ -109,6 +110,7 @@ func (a *Authenticator) authenticate(ctx context.Context) (_ context.Context, er
 		var remoteIP string
 		if remote, ok := peer.FromContext(ctx); ok {
 			remoteIP = remote.Addr.String()
+
 		}
 
 		hub.Scope().SetUser(sentry.User{
@@ -153,4 +155,18 @@ func (a *Authenticator) Stream() grpc.StreamServerInterceptor {
 func (a *Authenticator) isPublic(route string) bool {
 	_, ok := a.publicRoutes[route]
 	return ok
+}
+
+func UserIP(addr net.Addr) string {
+	// If this is a TCP ip address then handle it directly
+	if tcpaddr, ok := addr.(*net.TCPAddr); ok {
+		return tcpaddr.IP.String()
+	}
+
+	// Try parsing the IP address the hard way
+	ipaddr := addr.String()
+	if host, _, err := net.SplitHostPort(ipaddr); err == nil {
+		return host
+	}
+	return ipaddr
 }

--- a/pkg/ensign/interceptors/auth.go
+++ b/pkg/ensign/interceptors/auth.go
@@ -109,7 +109,7 @@ func (a *Authenticator) authenticate(ctx context.Context) (_ context.Context, er
 	if hub := sentry.GetHubFromContext(ctx); hub != nil {
 		var remoteIP string
 		if remote, ok := peer.FromContext(ctx); ok {
-			remoteIP = remote.Addr.String()
+			remoteIP = UserIP(remote.Addr)
 
 		}
 

--- a/pkg/ensign/interceptors/auth_test.go
+++ b/pkg/ensign/interceptors/auth_test.go
@@ -2,6 +2,7 @@ package interceptors_test
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	api "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
@@ -160,4 +161,24 @@ func TestAuthenticator(t *testing.T) {
 		require.Equal(t, health.HealthCheckResponse_SERVING, hb.Status)
 	})
 
+}
+
+func TestUserIP(t *testing.T) {
+	testCases := []struct {
+		addr     net.Addr
+		expected string
+	}{
+		{&net.TCPAddr{IP: net.ParseIP("192.168.0.1")}, "192.168.0.1"},
+		{&net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 17821}, "192.168.0.1"},
+		{&net.TCPAddr{IP: net.ParseIP("c266:8bf2:145e:3cb9:9f9e:2a24:ed17:b4e4")}, "c266:8bf2:145e:3cb9:9f9e:2a24:ed17:b4e4"},
+		{&net.TCPAddr{IP: net.ParseIP("c266:8bf2:145e:3cb9:9f9e:2a24:ed17:b4e4"), Port: 17821}, "c266:8bf2:145e:3cb9:9f9e:2a24:ed17:b4e4"},
+		{&net.TCPAddr{IP: net.ParseIP("c266:8bf2:145e:3cb9:9f9e:2a24:ed17:b4e4"), Port: 17821, Zone: "1"}, "c266:8bf2:145e:3cb9:9f9e:2a24:ed17:b4e4"},
+		{&net.UDPAddr{IP: net.ParseIP("192.168.0.1")}, "192.168.0.1"},
+		{&net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 17821}, "192.168.0.1"},
+	}
+
+	for i, tc := range testCases {
+		actual := interceptors.UserIP(tc.addr)
+		require.Equal(t, tc.expected, actual, "test case %d failed", i)
+	}
 }


### PR DESCRIPTION
### Scope of changes

Reduces verbosity of gRPC error messages by inspecting the gRPC status code. Also strips the port off of IP addresses in gRPC streaming so that the IP address is resolved correctly in Sentry.

Fixes SC-22129

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [x] other (devops)

### Acceptance criteria

1. Reduce verbosity of sentry errors - particularly EnSQL syntax errors 
2. Ensure the IP address of the user is part of the Sentry metadata

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] ~I have added new test fixtures as needed to support added tests~
- [ ] ~I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)~
- [ ] ~I have recompiled and included new protocol buffers to reflect changes I made if necessary~
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] ~Front-end: Checked sm, md, lg screen resolutions for effective responsiveness~
- [ ] ~Backend-end: Documented service configuration changes or created related devops stories~

### Reviewer(s) checklist

- [ ] ~Front-end: I've reviewed the Figma design and confirmed that changes match the spec.~
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

