### PR TITLE
Create Event Duplicate References

### DIFF
--- a/pkg/ensign/api/v1beta1/deduplication.go
+++ b/pkg/ensign/api/v1beta1/deduplication.go
@@ -320,6 +320,7 @@ func (w *EventWrapper) HashUniqueField(fields []string) (_ []byte, err error) {
 //===========================================================================
 
 // DuplicateOf marks the original event (w) as a duplicate of the original event (o).
+// In other words, the original event (w) becomes a duplicate reference to the original.
 // The duplicate is updated in place to mark the wrapper as a duplicate of the original
 // and to reduce the data storage depending on the policy. For example, in strict mode,
 // the event data is nilified and only the wrapper metadata is kept, whereas in unique

--- a/pkg/ensign/api/v1beta1/deduplication.go
+++ b/pkg/ensign/api/v1beta1/deduplication.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -312,6 +313,142 @@ func (w *EventWrapper) HashUniqueField(fields []string) (_ []byte, err error) {
 	}
 
 	return nil, errors.New("hash unique field is not implemented")
+}
+
+//===========================================================================
+// Duplicate Modification
+//===========================================================================
+
+// DuplicateOf marks the original event (w) as a duplicate of the original event (o).
+// The duplicate is updated in place to mark the wrapper as a duplicate of the original
+// and to reduce the data storage depending on the policy. For example, in strict mode,
+// the event data is nilified and only the wrapper metadata is kept, whereas in unique
+// keys mode, the data may not be removed depending on the policy.
+//
+// NOTE: this method does not check if the events are duplicates! Use the Duplicates()
+// method for verification that the two events are duplicates of each other.
+func (w *EventWrapper) DuplicateOf(o *EventWrapper, policy *Deduplication) (err error) {
+	if policy.Strategy == Deduplication_UNKNOWN || policy.Strategy == Deduplication_NONE {
+		return ErrDuplicatesNotAllowed
+	}
+
+	// Mark the current event as a duplicate of the original event
+	w.IsDuplicate = true
+	w.DuplicateId = o.Id
+
+	// Remove fields as necessary to reduce the storage load of the database.
+	// In STRICT mode - simply set the event to nil so we're not storing that data.
+	// Since there will be no encryption or compression, set those to nil as well.
+	// NOTE: this strategy will cause us to lose the created timestamp from the event,
+	// though the committed timestamp on the wrapper will still be kept.
+	if policy.Strategy == Deduplication_STRICT {
+		w.Event = nil
+		w.Encryption = nil
+		w.Compression = nil
+		return nil
+	}
+
+	// For all other modes we'll need to update the event record itself.
+	var event *Event
+	if event, err = w.Unwrap(); err != nil {
+		return err
+	}
+
+	var orig *Event
+	if orig, err = o.Unwrap(); err != nil {
+		return err
+	}
+
+	// If the policy is datagram or key grouped, then we know the data is identical so
+	// set it to nil. Otherwise, check to make sure the data is identical before
+	// deleting the data from the event
+	if policy.Strategy == Deduplication_DATAGRAM || policy.Strategy == Deduplication_KEY_GROUPED {
+		event.Data = nil
+	} else if bytes.Equal(event.Data, orig.Data) {
+		event.Data = nil
+	}
+
+	// Deduplicate the metadata, keeping only the keys that differ from the original
+	var meta map[string]string
+	for key, val := range event.Metadata {
+		if val != orig.Metadata[key] {
+			if meta == nil {
+				meta = make(map[string]string)
+			}
+			meta[key] = val
+		}
+	}
+	event.Metadata = meta
+
+	// Deduplicate the mimetype if they match
+	if event.Mimetype == orig.Mimetype {
+		event.Mimetype = 0
+	}
+
+	// Deduplicate the event type if they match
+	if event.Type.Equals(orig.Type) {
+		event.Type = nil
+	}
+
+	// Rewrap the event into the wrapper
+	return w.Wrap(event)
+}
+
+// DuplicateFrom is the inverse of DuplicateOf: it modifies the event w, populating it
+// with the duplicated data from the original event. It still keeps the event w marked
+// as a duplicate (this has to be undone manually), but it allows the duplicate to be
+// returned to the user with any unique information it may have contained.
+func (w *EventWrapper) DuplicateFrom(o *EventWrapper) (err error) {
+	// If the event data is nil, simply copy over the original event, encryption, and
+	// compression and return w. This is the case in strict mode.
+	if len(w.Event) == 0 {
+		w.Event = o.Event
+		w.Encryption = o.Encryption
+		w.Compression = o.Compression
+		return nil
+	}
+
+	// Otherwise unwrap the events to merge the data together
+	var event *Event
+	if event, err = w.Unwrap(); err != nil {
+		return err
+	}
+
+	var orig *Event
+	if orig, err = o.Unwrap(); err != nil {
+		return err
+	}
+
+	// If there is no event data, merge it from the original event.
+	if len(event.Data) == 0 {
+		event.Data = orig.Data
+	}
+
+	// If there is no event metadata, copy it, otherwise only copy the keys that are
+	// in original but not in the event.
+	//
+	// NOTE: this has the unfortunate side-effect that keys that were in the original
+	// event but were not in the original duplicate event will be copied over, causing
+	// a small data inconsistency issue.
+	if len(event.Metadata) == 0 {
+		event.Metadata = orig.Metadata
+	} else {
+		for key, val := range orig.Metadata {
+			if _, ok := event.Metadata[key]; !ok {
+				event.Metadata[key] = val
+			}
+		}
+	}
+
+	if event.Mimetype == 0 {
+		event.Mimetype = orig.Mimetype
+	}
+
+	if event.Type == nil {
+		event.Type = orig.Type
+	}
+
+	return w.Wrap(event)
 }
 
 //===========================================================================

--- a/pkg/ensign/api/v1beta1/deduplication_test.go
+++ b/pkg/ensign/api/v1beta1/deduplication_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/oklog/ulid/v2"
 	. "github.com/rotationalio/ensign/pkg/ensign/api/v1beta1"
 	mimetype "github.com/rotationalio/ensign/pkg/ensign/mimetype/v1beta1"
+	region "github.com/rotationalio/ensign/pkg/ensign/region/v1beta1"
+	"github.com/rotationalio/ensign/pkg/ensign/rlid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -593,6 +596,111 @@ func TestHashUniqueField(t *testing.T) {
 	}
 }
 
+func TestDuplicateReferencing(t *testing.T) {
+	setPublisherBravo := func(w *EventWrapper) {
+		w.Region = region.Region_LKE_EU_WEST_1A
+		w.Publisher = &Publisher{
+			PublisherId: "01HD1M0AVDVHPA4WA73MAA7NH7",
+			Ipaddr:      "192.148.21.133",
+			ClientId:    "data-ingestor-bravo",
+			UserAgent:   "Go-Ensign v0.11.0",
+		}
+	}
+
+	clone := func(t *testing.T, w *EventWrapper) *EventWrapper {
+		data, err := proto.Marshal(w)
+		require.NoError(t, err, "could not marshal event")
+
+		o := &EventWrapper{}
+		err = proto.Unmarshal(data, o)
+		require.NoError(t, err, "could not unmarshal event")
+		return o
+	}
+
+	execTest := func(t *testing.T, evt, dup *EventWrapper, policy *Deduplication) {
+		// Clone the duplicate for comparison purposes.
+		org := clone(t, dup)
+
+		// Mark the dup as a duplicate of evt
+		err := dup.DuplicateOf(evt, policy)
+		require.NoError(t, err, "could not take duplicate of event")
+		require.True(t, dup.IsDuplicate)
+		require.Equal(t, evt.Id, dup.DuplicateId)
+		require.NotNil(t, dup.Event, "expected event data remaining")
+		require.Less(t, len(dup.Event), len(evt.Event), "expected the duplicate event size to be reduced")
+		require.NotEqual(t, evt.Committed, dup.Committed, "expected committed timestamp to still differ")
+		require.False(t, proto.Equal(org, dup), "expected the duplicate event to be modified")
+
+		// Restore the duplicate from the original event
+		err = dup.DuplicateFrom(evt)
+		require.NoError(t, err, "could restore duplicate from event")
+		require.True(t, org.Equals(dup), "expected event to be equal after duplicate resoration")
+	}
+
+	t.Run("Strict", func(t *testing.T) {
+		evt := mkwevt("tgRkJ4Q2otHC/wJFpePDd+YLwkBQPefGPzfldeIzZKz2wvzfFvNuUrifU7E7ritvFKUcmxW0aR8uGOVTNq1jBA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T09:41:19-05:00")
+		dup := mkwevt("tgRkJ4Q2otHC/wJFpePDd+YLwkBQPefGPzfldeIzZKz2wvzfFvNuUrifU7E7ritvFKUcmxW0aR8uGOVTNq1jBA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T16:32:21-05:00")
+		setPublisherBravo(dup)
+
+		// Clone the duplicate for comparison purposes.
+		org := clone(t, dup)
+
+		// Mark the dup as a duplicate of evt
+		err := dup.DuplicateOf(evt, &Deduplication{Strategy: Deduplication_STRICT})
+		require.NoError(t, err, "could not take duplicate of event")
+		require.True(t, dup.IsDuplicate)
+		require.Equal(t, evt.Id, dup.DuplicateId)
+		require.Nil(t, dup.Event, "expected event data to be nil")
+		require.Nil(t, dup.Encryption, "expected encryption to be nil")
+		require.Nil(t, dup.Compression, "expected compression to be nil")
+		require.NotEqual(t, evt.Committed, dup.Committed, "expected committed timestamp to still differ")
+		require.False(t, proto.Equal(org, dup), "expeced the duplicate event to be modified")
+
+		// Restore the duplicate from the original event
+		err = dup.DuplicateFrom(evt)
+		require.NoError(t, err, "could restore duplicate from event")
+		require.True(t, org.Equals(dup), "expected event to be equal after duplicate resoration")
+	})
+
+	t.Run("Datagram", func(t *testing.T) {
+		evt := mkwevt("tgRkJ4Q2otHC/wJFpePDd+YLwkBQPefGPzfldeIzZKz2wvzfFvNuUrifU7E7ritvFKUcmxW0aR8uGOVTNq1jBA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T09:41:19-05:00")
+		dup := mkwevt("tgRkJ4Q2otHC/wJFpePDd+YLwkBQPefGPzfldeIzZKz2wvzfFvNuUrifU7E7ritvFKUcmxW0aR8uGOVTNq1jBA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T16:32:21-05:00")
+		setPublisherBravo(dup)
+		execTest(t, evt, dup, &Deduplication{Strategy: Deduplication_DATAGRAM})
+	})
+
+	t.Run("Datagram_Metadata", func(t *testing.T) {
+		evt := mkwevt("tgRkJ4Q2otHC/wJFpePDd+YLwkBQPefGPzfldeIzZKz2wvzfFvNuUrifU7E7ritvFKUcmxW0aR8uGOVTNq1jBA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T09:41:19-05:00")
+		dup := mkwevt("tgRkJ4Q2otHC/wJFpePDd+YLwkBQPefGPzfldeIzZKz2wvzfFvNuUrifU7E7ritvFKUcmxW0aR8uGOVTNq1jBA==", "foo:bar,color:blue,jack:jones", mimetype.MIME_APPLICATION_JSON, "TestVersion 1.4.4", "2023-10-18T16:32:21-05:00")
+		setPublisherBravo(dup)
+		execTest(t, evt, dup, &Deduplication{Strategy: Deduplication_DATAGRAM})
+	})
+
+	t.Run("KeyGrouped", func(t *testing.T) {
+		// TODO: implement this test!
+		t.Skip("not implemented yet")
+	})
+
+	t.Run("UniqueKey", func(t *testing.T) {
+		evt := mkwevt("VzcrPlcPKWG/dapHfLnfiA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T09:41:19-05:00")
+		dup := mkwevt("VzcrPlcPKWG/dapHfLnfiA==", "foo:bar,color:blue,jack:jones", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T16:32:21-05:00")
+		setPublisherBravo(dup)
+		execTest(t, evt, dup, &Deduplication{Strategy: Deduplication_UNIQUE_KEY, Keys: []string{"foo"}})
+	})
+
+	t.Run("UniqueKey_Data", func(t *testing.T) {
+		evt := mkwevt("VzcrPlcPKWG/dapHfLnfiA==", "foo:bar,color:red", mimetype.MIME_APPLICATION_BSON, "TestVersion 1.2.3", "2023-10-18T09:41:19-05:00")
+		dup := mkwevt("64azNXY/sTehGqN3Fk7kbw==", "foo:bar,color:red,jack:jones", mimetype.MIME_APPLICATION_JSON, "TestVersion 1.4.4", "2023-10-18T16:32:21-05:00")
+		setPublisherBravo(dup)
+		execTest(t, evt, dup, &Deduplication{Strategy: Deduplication_UNIQUE_KEY, Keys: []string{"foo"}})
+	})
+
+	t.Run("UniqueField", func(t *testing.T) {
+		// TODO: implement this test!
+		t.Skip("not implemented yet")
+	})
+}
+
 func TestDeduplicationEquals(t *testing.T) {
 	testCases := []struct {
 		alpha  *Deduplication
@@ -833,13 +941,29 @@ func generateFixtures() (err error) {
 	return nil
 }
 
+var seq rlid.Sequence
+
 // Helper to quickly make event wrappers with a topicID and committed timestamp, using a
 // similar methodology to mkevt to generate the underlying event.
 func mkwevt(data, kvs string, mime mimetype.MIME, etype, created string) *EventWrapper {
 	event := mkevt(data, kvs, mime, etype, created)
+	eventID := seq.Next()
+
 	wrap := &EventWrapper{
+		Id:        eventID.Bytes(),
 		TopicId:   ulid.MustParse("01HBETJKP2ES10XXMK27M651GA").Bytes(),
 		Committed: timestamppb.Now(),
+		Offset:    uint64(eventID.Sequence()),
+		Epoch:     uint64(0xe1),
+		Region:    region.Region_LKE_US_EAST_1A,
+		Publisher: &Publisher{
+			PublisherId: "01HD1KY309F3SHSV1M89GSQBDF",
+			Ipaddr:      "192.168.1.1",
+			ClientId:    "data-ingestor-alpha",
+			UserAgent:   "PyEnsign v0.12.0",
+		},
+		Encryption:  &Encryption{EncryptionAlgorithm: Encryption_PLAINTEXT},
+		Compression: &Compression{Algorithm: Compression_NONE},
 	}
 	wrap.Wrap(event)
 	return wrap
@@ -858,7 +982,23 @@ func createRandomEvent(mime mimetype.MIME, etype, meta string) *EventWrapper {
 		}
 	}
 
-	wrap := &EventWrapper{}
+	eventID := seq.Next()
+	wrap := &EventWrapper{
+		Id:        eventID.Bytes(),
+		TopicId:   ulid.MustParse("01HBETJKP2ES10XXMK27M651GA").Bytes(),
+		Committed: timestamppb.Now(),
+		Offset:    uint64(eventID.Sequence()),
+		Epoch:     uint64(0xe1),
+		Region:    region.Region_LKE_US_EAST_1A,
+		Publisher: &Publisher{
+			PublisherId: "01HD1KY309F3SHSV1M89GSQBDF",
+			Ipaddr:      "192.168.1.1",
+			ClientId:    "data-ingestor-alpha",
+			UserAgent:   "PyEnsign v0.12.0",
+		},
+		Encryption:  &Encryption{EncryptionAlgorithm: Encryption_PLAINTEXT},
+		Compression: &Compression{Algorithm: Compression_NONE},
+	}
 	wrap.Wrap(event)
 	return wrap
 }

--- a/pkg/ensign/api/v1beta1/errors.go
+++ b/pkg/ensign/api/v1beta1/errors.go
@@ -5,10 +5,11 @@ import "errors"
 // Statically defined errors for error checking the type of error returned by a method
 // or function in the api package.
 var (
-	ErrNoEvent          = errors.New("event wrapper contains no event")
-	ErrNoKeys           = errors.New("no keys specified for key based hashing")
-	ErrNoFields         = errors.New("no fields specified for field based hashing")
-	ErrKeysNotAllowed   = errors.New("do not specify keys for this policy")
-	ErrFieldsNotAllowed = errors.New("do not specify fields for this policy")
-	ErrNoGroupID        = errors.New("consumer group requires either id or name")
+	ErrNoEvent              = errors.New("event wrapper contains no event")
+	ErrNoKeys               = errors.New("no keys specified for key based hashing")
+	ErrNoFields             = errors.New("no fields specified for field based hashing")
+	ErrKeysNotAllowed       = errors.New("do not specify keys for this policy")
+	ErrFieldsNotAllowed     = errors.New("do not specify fields for this policy")
+	ErrNoGroupID            = errors.New("consumer group requires either id or name")
+	ErrDuplicatesNotAllowed = errors.New("duplicates not allowed by specified policy")
 )

--- a/pkg/ensign/api/v1beta1/event.go
+++ b/pkg/ensign/api/v1beta1/event.go
@@ -51,13 +51,34 @@ func (w *EventWrapper) ParseTopicID() (topicID ulid.ULID, err error) {
 	return topicID, nil
 }
 
-// Parwse the eventID on the event wrapper as an RLID.
+// Parse the eventID on the event wrapper as an RLID.
 func (w *EventWrapper) ParseEventID() (eventID rlid.RLID, err error) {
 	eventID = rlid.RLID{}
 	if err = eventID.UnmarshalBinary(w.Id); err != nil {
 		return eventID, err
 	}
 	return eventID, nil
+}
+
+// Equals compares two events in wrappers to see if they are identical using event
+// equality. This is essentially a shortcut for unwrapping the two events and comparing
+// them directly.
+func (w *EventWrapper) Equals(o *EventWrapper) bool {
+	event, err := o.Unwrap()
+	if err != nil {
+		return false
+	}
+	return w.EqualsEvent(event)
+}
+
+// Equals compares a wrapped event to an wrapped event to see if the wrapped event is
+// identical using event equality. This is a shortcut for unwrapping the wrapped event.
+func (w *EventWrapper) EqualsEvent(o *Event) bool {
+	event, err := w.Unwrap()
+	if err != nil {
+		return false
+	}
+	return event.Equals(o)
 }
 
 //===========================================================================

--- a/pkg/ensign/store/events/events.go
+++ b/pkg/ensign/store/events/events.go
@@ -97,7 +97,7 @@ func (s *Store) Retrieve(topicId ulid.ULID, eventID rlid.RLID) (event *api.Event
 
 	var data []byte
 	if data, err = s.db.Get(key[:], nil); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 
 	event = &api.EventWrapper{}

--- a/pkg/ensign/store/events/indash_test.go
+++ b/pkg/ensign/store/events/indash_test.go
@@ -46,6 +46,58 @@ func (s *readonlyEventsTestSuite) TestIndash() {
 	require.ErrorIs(err, errors.ErrReadOnly, "expected readonly error on indash")
 }
 
+func (s *eventsTestSuite) TestUnhash() {
+	require := s.Require()
+	require.False(s.store.ReadOnly())
+
+	_, err := s.LoadAllFixtures()
+	require.NoError(err, "could not load fixtures")
+	defer s.ResetDatabase()
+
+	s.Run("Happy", func() {
+		topicID := ulid.MustParse("01GTSN1139JMK1PS5A524FXWAZ")
+		hash, _ := base64.RawStdEncoding.DecodeString("ZYoBI+8RmyL/K4DNYRgGZg")
+		eventID := rlid.MustParse("064yrcthc0000004").Bytes()
+
+		event, err := s.store.Unhash(topicID, hash)
+		require.NoError(err, "could not unhash event")
+		require.NotNil(event, "a nil event was reteurned")
+		require.Equal(eventID, event.Id)
+	})
+
+	s.Run("NotFound", func() {
+		topicID := ulid.MustParse("01GTSN1139JMK1PS5A524FXWAZ")
+		hash, _ := base64.RawStdEncoding.DecodeString("vKVUKp4k4EMz8TKaWgAvlQ")
+
+		_, err := s.store.Unhash(topicID, hash)
+		require.ErrorIs(err, errors.ErrNotFound)
+	})
+}
+
+func (s *readonlyEventsTestSuite) TestUnhash() {
+	require := s.Require()
+	require.True(s.store.ReadOnly())
+
+	s.Run("Happy", func() {
+		topicID := ulid.MustParse("01GTSN1139JMK1PS5A524FXWAZ")
+		hash, _ := base64.RawStdEncoding.DecodeString("ZYoBI+8RmyL/K4DNYRgGZg")
+		eventID := rlid.MustParse("064yrcthc0000004").Bytes()
+
+		event, err := s.store.Unhash(topicID, hash)
+		require.NoError(err, "could not unhash event")
+		require.NotNil(event, "a nil event was reteurned")
+		require.Equal(eventID, event.Id)
+	})
+
+	s.Run("NotFound", func() {
+		topicID := ulid.MustParse("01GTSN1139JMK1PS5A524FXWAZ")
+		hash, _ := base64.RawStdEncoding.DecodeString("vKVUKp4k4EMz8TKaWgAvlQ")
+
+		_, err := s.store.Unhash(topicID, hash)
+		require.ErrorIs(err, errors.ErrNotFound)
+	})
+}
+
 func (s *eventsTestSuite) TestLoadIndash() {
 	require := s.Require()
 	require.False(s.store.ReadOnly())

--- a/pkg/ensign/store/events/keys.go
+++ b/pkg/ensign/store/events/keys.go
@@ -92,6 +92,8 @@ func (s Segment) String() string {
 		return "event"
 	case MetaEventSegment:
 		return "metaevent"
+	case IndashSegment:
+		return "indash"
 	default:
 		return "unknown"
 	}

--- a/pkg/ensign/store/store.go
+++ b/pkg/ensign/store/store.go
@@ -62,6 +62,7 @@ type EventStore interface {
 type EventHashStore interface {
 	// Indash is a combination of "Index" and "Hash"
 	Indash(topicID ulid.ULID, hash []byte, eventID rlid.RLID) error
+	Unhash(topicID ulid.ULID, hash []byte) (*api.EventWrapper, error)
 	LoadIndash(topicID ulid.ULID) iterator.IndashIterator
 	ClearIndash(topicID ulid.ULID) error
 }


### PR DESCRIPTION
### Scope of changes

Implements a mechanism for an event to reference another event in the stream. 

Fixes SC-20993

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

- Create a storage mechanism to refer to a duplicate in the event stream.
- This should also include any changes to the metadata for the indicated event.

### Definition of Done

- [ ] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] ~Front-end: Checked sm, md, lg screen resolutions for effective responsiveness~
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] ~Front-end: I've reviewed the Figma design and confirmed that changes match the spec.~
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

