### PR TITLE
Update Topic Info with Duplicates

### DIFF
--- a/pkg/ensign/api/v1beta1/event.go
+++ b/pkg/ensign/api/v1beta1/event.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/rotationalio/ensign/pkg/ensign/rlid"
@@ -224,4 +225,14 @@ func (t *Type) Equals(o *Type) bool {
 // patch versions are equal to zero.
 func (t *Type) IsZero() bool {
 	return (t.Name == "" || t.Name == Unspecified) && t.MajorVersion == 0 && t.MinorVersion == 0 && t.PatchVersion == 0
+}
+
+// Repr returns the string representation of the type.
+func (t *Type) Repr() string {
+	return fmt.Sprintf("%s v%d.%d.%d", t.Name, t.MajorVersion, t.MinorVersion, t.PatchVersion)
+}
+
+// Semver returns the semantic version of the type.
+func (t *Type) Semver() string {
+	return fmt.Sprintf("%d.%d.%d", t.MajorVersion, t.MinorVersion, t.PatchVersion)
 }

--- a/pkg/ensign/info/testdata/phase2.json
+++ b/pkg/ensign/info/testdata/phase2.json
@@ -11,20 +11,42 @@
       "shards": 1,
       "placements": [],
       "types": []
-    },
-    {
-      "id": "AYazUVb7MGwsE4/zw1eGUA",
-      "id_ulid": "01GTSN2NQV61P2R4WFYF1NF1JG",
-      "project_id": "AYazT9ce7VX7vLhFY3CStA",
-      "project_id_ulid": "01GTSMZNRYXNAZQF5R8NHQ14NM",
-      "name": "mock.mockapp.post",
-      "readonly": true,
-      "offset": 15,
-      "shards": 1,
-      "placements": [],
-      "types": []
     }
   ],
-  "events": [],
+  "events": [
+    {
+      "is_duplicate": true,
+      "duplicate_id": "AYnsM1FgAAAAAg==",
+      "committed": "2023-03-06T19:44:53.919257728Z",
+      "compression": {
+        "algorithm": "NONE",
+        "level": "0"
+      },
+      "encryption": {
+        "encryption_algorithm": "PLAINTEXT",
+        "encryption_key": "",
+        "hmac_secret": "",
+        "public_key_id": "",
+        "sealing_algorithm": "PLAINTEXT",
+        "signature": "",
+        "signature_algorithm": "PLAINTEXT"
+      },
+      "epoch": "1",
+      "event": "",
+      "id": "AYnsM1FgAAAAGh==",
+      "key": "",
+      "local_id": "AYazTjh7uLgl64oE46nrkA==",
+      "offset": "2",
+      "publisher": {
+        "client_id": "2E90F475",
+        "ipaddr": "",
+        "publisher_id": "01GTSMP8NTPMCENM1HHV92BZSX",
+        "user_agent": ""
+      },
+      "region": "STG_LKE_US_EAST_1A",
+      "shard": "1",
+      "topic_id": "AYazTPQ0TAXyF3CBKBFxgA=="
+    }
+  ],
   "infos": []
 }

--- a/pkg/ensign/topics.go
+++ b/pkg/ensign/topics.go
@@ -101,6 +101,11 @@ func (s *Server) CreateTopic(ctx context.Context, in *api.Topic) (_ *api.Topic, 
 		return nil, status.Error(codes.PermissionDenied, "not authorized to perform this action")
 	}
 
+	// Set topic default policies if they are not set on the topic
+	if in.Deduplication == nil || in.Deduplication.Strategy == api.Deduplication_UNKNOWN {
+		in.Deduplication = &api.Deduplication{Strategy: api.Deduplication_NONE}
+	}
+
 	// TODO: set the topic status as pending
 
 	// Create the topic in the store: note that the store will validate the topic


### PR DESCRIPTION
### Scope of changes

Updates TopicInfo to track duplicates.
Also fixes a bug to ensure the topic deduplication policy is initialized correctly.

Note that tests are fairly light since we're going to remove this background routine and push info gathering into the broker.

Fixes SC-21001

### Type of change

- [x] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Make sure topic info includes the number of duplicates.

### Definition of Done

- [ ] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [x] I have added unit and/or integration tests that cover my changes
- [x] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

