### PR TITLE
Remove stranded orgs cleanup

### DIFF
--- a/pkg/quarterdeck/db/models/users.go
+++ b/pkg/quarterdeck/db/models/users.go
@@ -719,7 +719,7 @@ const (
 // ListOrgUsers returns a paginated collection of users filtered by the orgID.
 // The orgID must be a valid non-zero value of type ulid.ULID,
 // a string representation of a type ulid.ULID, or a slice of bytes
-// The number of users resturned is controlled by the prevPage cursor.
+// The number of users returned is controlled by the prevPage cursor.
 // To return the first page with a default number of results pass nil for the prevPage;
 // Otherwise pass an empty page with the specified PageSize.
 // If the prevPage contains an EndIndex then the next page is returned.
@@ -1084,7 +1084,7 @@ func (u *User) RemoveOrganization(ctx context.Context, orgID any, force bool) (k
 	// If the user doesn't have any organizations then delete the user
 	if _, err = u.defaultOrganization(tx); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			if err = u.delete(tx); err != nil {
+			if err = u.Delete(tx); err != nil {
 				return nil, "", err
 			}
 		} else {
@@ -1190,7 +1190,7 @@ const (
 // Delete the user from the database. This is normally not done directly but as a
 // result of removing the user from all their organizations.
 // TODO: Preserve the email address <> user ID mapping.
-func (u *User) delete(tx *sql.Tx) (err error) {
+func (u *User) Delete(tx *sql.Tx) (err error) {
 	if _, err = tx.Exec(deleteUserSQL, sql.Named("userID", u.ID)); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Scope of changes

This adds a cleanup command for removing stranded organizations and edits the cleanup users command to correctly delete the user's organization.

Fixes SC-21496

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [x] devops

### Acceptance criteria

We need a cleanup script to deal with the stranded organizations in Quarterdeck (those that have no users).

### Definition of Done

- [ ] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

