### PR TITLE
Prevents users from logging out before accepting invitations to join a team

### DIFF
--- a/web/beacon-app/src/application/api/ApiAdapters.ts
+++ b/web/beacon-app/src/application/api/ApiAdapters.ts
@@ -67,4 +67,5 @@ export interface ApiAdapters {
   forgotPassword(email: ForgotPasswordDTO): Promise<any>;
   resetPassword(payload: ResetPasswordDTO): Promise<any>;
   getStatus(): Promise<StatusResponse>;
+  getInviteAuthenticationRequest(token: string): Promise<any>;
 }

--- a/web/beacon-app/src/application/api/ApiAdapters.ts
+++ b/web/beacon-app/src/application/api/ApiAdapters.ts
@@ -67,5 +67,5 @@ export interface ApiAdapters {
   forgotPassword(email: ForgotPasswordDTO): Promise<any>;
   resetPassword(payload: ResetPasswordDTO): Promise<any>;
   getStatus(): Promise<StatusResponse>;
-  getInviteAuthenticationRequest(token: string): Promise<any>;
+  getInvitationAuthentication(token: string): Promise<any>;
 }

--- a/web/beacon-app/src/constants/queryKeys.ts
+++ b/web/beacon-app/src/constants/queryKeys.ts
@@ -24,4 +24,5 @@ export const RQK = {
   TOPIC_STATS: 'topic-stats',
   PROFILE: 'profile',
   STATUS: 'status',
+  INVITE_AUTHENTICATION: 'invite-authentication',
 } as const;

--- a/web/beacon-app/src/constants/queryKeys.ts
+++ b/web/beacon-app/src/constants/queryKeys.ts
@@ -24,5 +24,5 @@ export const RQK = {
   TOPIC_STATS: 'topic-stats',
   PROFILE: 'profile',
   STATUS: 'status',
-  INVITE_AUTHENTICATION: 'invite-authentication',
+  INVITATION_AUTHENTICATION: 'invitation-authentication',
 } as const;

--- a/web/beacon-app/src/features/home/routes/Home.tsx
+++ b/web/beacon-app/src/features/home/routes/Home.tsx
@@ -9,7 +9,7 @@ import WelcomeAttention from '../components/WelcomeAttention';
 export default function Home() {
   const store = useOrgStore((state) => state) as any;
   const isAuthenticated = store.isAuthenticated;
-  setCookie('isAuthenticated', isAuthenticated as string);
+  setCookie('authenticatedUser', isAuthenticated as string);
 
   return (
     <AppLayout>

--- a/web/beacon-app/src/features/home/routes/Home.tsx
+++ b/web/beacon-app/src/features/home/routes/Home.tsx
@@ -1,10 +1,16 @@
 import AppLayout from '@/components/layout/AppLayout';
+import { useOrgStore } from '@/store';
+import { setCookie } from '@/utils/cookies';
 
 import QuickStart from '../components/QuickStart';
 import StarterVideos from '../components/StarterVideos/StarterVideo';
 import WelcomeAttention from '../components/WelcomeAttention';
 
 export default function Home() {
+  const store = useOrgStore((state) => state) as any;
+  const isAuthenticated = store.isAuthenticated;
+  setCookie('isAuthenticated', isAuthenticated as string);
+
   return (
     <AppLayout>
       <WelcomeAttention />

--- a/web/beacon-app/src/features/teams/api/getInviteAuthenticationRequest.ts
+++ b/web/beacon-app/src/features/teams/api/getInviteAuthenticationRequest.ts
@@ -1,0 +1,19 @@
+import { ApiAdapters } from '@/application/api/ApiAdapters';
+import { getValidApiResponse, Request } from '@/application/api/ApiService';
+import { APP_ROUTE } from '@/constants';
+import { UserAuthResponse } from '@/features/auth';
+
+export function getInviteAuthenticationRequest(
+  request: Request
+): ApiAdapters['getInviteAuthenticationRequest'] {
+  return async (token: string) => {
+    const response = (await request(`${APP_ROUTE.INVITE}/accept`, {
+      method: 'POST',
+      data: {
+        token,
+      },
+    })) as any;
+
+    return getValidApiResponse<UserAuthResponse>(response);
+  };
+}

--- a/web/beacon-app/src/features/teams/api/invitationAuthenticationRequest.ts
+++ b/web/beacon-app/src/features/teams/api/invitationAuthenticationRequest.ts
@@ -3,9 +3,9 @@ import { getValidApiResponse, Request } from '@/application/api/ApiService';
 import { APP_ROUTE } from '@/constants';
 import { UserAuthResponse } from '@/features/auth';
 
-export function getInviteAuthenticationRequest(
+export function invitationAuthenticationRequest(
   request: Request
-): ApiAdapters['getInviteAuthenticationRequest'] {
+): ApiAdapters['getInvitationAuthentication'] {
   return async (token: string) => {
     const response = (await request(`${APP_ROUTE.INVITE}/accept`, {
       method: 'POST',

--- a/web/beacon-app/src/features/teams/components/ExistingUserInvitationPage.tsx
+++ b/web/beacon-app/src/features/teams/components/ExistingUserInvitationPage.tsx
@@ -43,7 +43,7 @@ export default function ExistingUserInvitationPage({ data }: { data: any }) {
         const token = decodeToken(authData?.access_token) as any;
         Store.setAuthUser(token, !!authData?.access_token);
 
-        navigate(APP_ROUTE.DASHBOARD);        
+        navigate(APP_ROUTE.DASHBOARD);
       }
     }
   }, [

--- a/web/beacon-app/src/features/teams/hooks/useFetchInviteAuthentication.ts
+++ b/web/beacon-app/src/features/teams/hooks/useFetchInviteAuthentication.ts
@@ -3,20 +3,20 @@ import { useMutation } from '@tanstack/react-query';
 import axiosInstance from '@/application/api/ApiService';
 import { RQK } from '@/constants';
 
-import { getInviteAuthenticationRequest } from '../api/getInviteAuthenticationRequest';
+import { invitationAuthenticationRequest } from '../api/invitationAuthenticationRequest';
 
 export function useFetchInviteAuthentication(token: string): any {
   const mutation = useMutation([RQK.INVITE_AUTHENTICATION, token], () =>
-    getInviteAuthenticationRequest(axiosInstance)(token)
+    invitationAuthenticationRequest(axiosInstance)(token)
   );
 
   return {
-    invite: mutation.mutate,
+    invitationRequest: mutation.mutate,
     reset: mutation.reset,
-    auth: mutation.data,
-    hasInviteAuthenticationFailed: mutation.isError,
-    isFetchingInviteAuthentication: mutation.isLoading,
-    wasInviteAuthenticated: mutation.isSuccess,
+    authData: mutation.data,
+    hasInvitationAuthenticationFailed: mutation.isError,
+    isFetchingInvitationAuthentication: mutation.isLoading,
+    wasInvitationAuthenticated: mutation.isSuccess,
     error: mutation.error,
   };
 }

--- a/web/beacon-app/src/features/teams/hooks/useFetchInviteAuthentication.ts
+++ b/web/beacon-app/src/features/teams/hooks/useFetchInviteAuthentication.ts
@@ -6,7 +6,7 @@ import { RQK } from '@/constants';
 import { invitationAuthenticationRequest } from '../api/invitationAuthenticationRequest';
 
 export function useFetchInviteAuthentication(token: string): any {
-  const mutation = useMutation([RQK.INVITE_AUTHENTICATION, token], () =>
+  const mutation = useMutation([RQK.INVITATION_AUTHENTICATION, token], () =>
     invitationAuthenticationRequest(axiosInstance)(token)
   );
 

--- a/web/beacon-app/src/features/teams/hooks/useFetchInviteAuthentication.ts
+++ b/web/beacon-app/src/features/teams/hooks/useFetchInviteAuthentication.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+
+import axiosInstance from '@/application/api/ApiService';
+import { RQK } from '@/constants';
+
+import { getInviteAuthenticationRequest } from '../api/getInviteAuthenticationRequest';
+
+export function useFetchInviteAuthentication(token: string): any {
+  const mutation = useMutation([RQK.INVITE_AUTHENTICATION, token], () =>
+    getInviteAuthenticationRequest(axiosInstance)(token)
+  );
+
+  return {
+    invite: mutation.mutate,
+    reset: mutation.reset,
+    auth: mutation.data,
+    hasInviteAuthenticationFailed: mutation.isError,
+    isFetchingInviteAuthentication: mutation.isLoading,
+    wasInviteAuthenticated: mutation.isSuccess,
+    error: mutation.error,
+  };
+}
+
+export default useFetchInviteAuthentication;

--- a/web/beacon-app/src/features/teams/types/invites.ts
+++ b/web/beacon-app/src/features/teams/types/invites.ts
@@ -1,0 +1,17 @@
+import { UseMutateFunction } from '@tanstack/react-query';
+
+import { UserAuthResponse } from '@/features/auth';
+
+export interface InviteAuthenticationMutation {
+  invite: UseMutateFunction<UserAuthResponse, unknown, InviteAuthenticationDTO, unknown>;
+  reset(): void;
+  auth: UserAuthResponse;
+  hasInviteAuthenticationFailed: boolean;
+  wasAuthenticated: boolean;
+  isFetchingInviteAuthentication: boolean;
+  error: any;
+}
+
+export interface InviteAuthenticationDTO {
+  token: string;
+}


### PR DESCRIPTION
### Scope of changes

Prevents users from having to log out to accept an invitation request while logged into Beacon.

Fixes SC-21664

Note: When the user accepts an invite, a new tab or window opens, and they're logged out of their previous session. I can add a follow on story that displays an error explaining why the user is logged out if they return to the previous tab or window.

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

https://www.awesomescreenshot.com/video/22679550?key=d116cb41d88cda4cfa85bfdc929ad5de

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

