### PR TITLE
Adds max height to create api key modal to make permissions visible

### DIFF
--- a/web/beacon-app/src/features/apiKeys/components/GenerateAPIKeyModal.tsx
+++ b/web/beacon-app/src/features/apiKeys/components/GenerateAPIKeyModal.tsx
@@ -108,7 +108,7 @@ function GenerateAPIKeyModal({ open, onSetKey, onClose, projectId }: GenerateAPI
     <Modal
       open={open}
       title={t`Customize Your API Key`}
-      containerClassName="create-key-modal"
+      containerClassName="create-key-modal max-h-screen"
       onClose={onClose}
       data-testid="keyModal"
     >


### PR DESCRIPTION
### Scope of changes

Adds a max height to the create api key modal to make custom permissions visible.

Note: I was unable to override a `no-scrollbar` style to make a scrollbar visible. However, users should be able to scroll down to view the custom permissions, after the checkbox is selected, and then click the button to create an API key.

Fixes SC-22777

### Type of change

- [ ] new feature
- [x] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

In the video below, the change is tested in Chrome and the Sizzy browser.

https://www.awesomescreenshot.com/video/22905091?key=d225673cc3bd0334dc5cb744374ae32d

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [x] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

