### PR TITLE
Replaces beta with sandbox & removes extra percent sign from events data

### DIFF
--- a/web/beacon-app/src/components/auth/LandingHeader/LandingHeader.tsx
+++ b/web/beacon-app/src/components/auth/LandingHeader/LandingHeader.tsx
@@ -50,7 +50,7 @@ function LandingHeader() {
             </Link>
           )}
           <Link to="/" className="font-bold capitalize text-primary">
-            Ensign Beta
+            Ensign Sandbox
           </Link>
           {/* <Link to="/">
             <Button variant="tertiary" size="small">

--- a/web/beacon-app/src/features/topics/utils.ts
+++ b/web/beacon-app/src/features/topics/utils.ts
@@ -170,7 +170,7 @@ export const getFormattedEventDetailData = (events: TopicEvents[]) => {
       events: {
         ...event?.events,
         value: formatNumberByLocale(event?.events?.value),
-        percent: `${formatNumberByLocale(event?.events?.percent)}%`,
+        percent: `${formatNumberByLocale(event?.events?.percent)}`,
       },
     };
   });


### PR DESCRIPTION
### Scope of changes

Changes `Ensign Beta` copy in header to `Ensign Sandbox`. Also removes a duplicate `%` from util used to format the events table data.

Fixes SC-22878 & SC-22815

### Type of change

- [ ] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [ ] technical debt
- [ ] other (describe)

### Acceptance criteria

Sandbox change:
https://www.awesomescreenshot.com/image/44687854?key=51ae31608c1c27b47b7af64ca66ad643

Events data table w/o duplicate `%`:
https://www.awesomescreenshot.com/image/44687696?key=6a7bc4ed3782765883fffd0866ba56c4

### Definition of Done

- [x] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [ ] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [ ] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

