### PR TITLE
Add account type default sandbox to claims

### DIFF
--- a/pkg/quarterdeck/auth.go
+++ b/pkg/quarterdeck/auth.go
@@ -373,12 +373,14 @@ func (s *Server) Authenticate(c *gin.Context) {
 	}
 
 	// Create the access and refresh tokens and return them.
+	// TODO: add account type from database rather than hardcoding "sandbox"
 	claims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: apikey.ID.String(),
 		},
-		OrgID:     apikey.OrgID.String(),
-		ProjectID: apikey.ProjectID.String(),
+		OrgID:       apikey.OrgID.String(),
+		ProjectID:   apikey.ProjectID.String(),
+		AccountType: "sandbox",
 	}
 
 	// Add the key permissions to the claims.
@@ -549,13 +551,15 @@ func (s *Server) refreshUser(c *gin.Context, userID, orgID any) (_ *tokens.Claim
 	}
 
 	// Create a new claims object using the user retrieved from the database
+	// TODO: add account type from database rather than hardcoding "sandbox"
 	refreshClaims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: user.ID.String(),
 		},
-		Name:    user.Name,
-		Email:   user.Email,
-		Picture: gravatar.New(user.Email, nil),
+		Name:        user.Name,
+		Email:       user.Email,
+		Picture:     gravatar.New(user.Email, nil),
+		AccountType: "sandbox",
 	}
 
 	// Add the orgID to the claims
@@ -637,12 +641,14 @@ func (s *Server) refreshAPIKey(c *gin.Context, keyIDs, orgIDs any) (_ *tokens.Cl
 	}
 
 	// Create a new refreshClaims object using the apikey retrieved from the database
+	// TODO: add account type from database rather than hardcoding "sandbox"
 	refreshClaims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: apikey.ID.String(),
 		},
-		OrgID:     apikey.OrgID.String(),
-		ProjectID: apikey.ProjectID.String(),
+		OrgID:       apikey.OrgID.String(),
+		ProjectID:   apikey.ProjectID.String(),
+		AccountType: "sandbox",
 	}
 
 	// Add the key permissions to the claims.
@@ -736,14 +742,16 @@ func (s *Server) Switch(c *gin.Context) {
 	// Create access and refresh tokens for new organization
 	// NOTE: ensure that new claims are created and returned, not the old claims;
 	// otherwise the user may receive incorrect permissions.
+	// TODO: add account type from database rather than hardcoding "sandbox"
 	newClaims := &tokens.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: user.ID.String(),
 		},
-		Name:    user.Name,
-		Email:   user.Email,
-		Picture: gravatar.New(user.Email, nil),
-		OrgID:   in.OrgID.String(),
+		Name:        user.Name,
+		Email:       user.Email,
+		Picture:     gravatar.New(user.Email, nil),
+		OrgID:       in.OrgID.String(),
+		AccountType: "sandbox",
 	}
 
 	// Add the user permissions to the claims

--- a/pkg/quarterdeck/db/models/users.go
+++ b/pkg/quarterdeck/db/models/users.go
@@ -1195,13 +1195,15 @@ func (u *User) Delete(tx *sql.Tx) (err error) {
 // the user has already been loaded into an organization, otherwise an error is
 // returned.
 func (u *User) NewClaims(ctx context.Context) (claims *qd.Claims, err error) {
+	// TODO: add account type from database rather than hardcoding "sandbox"
 	claims = &qd.Claims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject: u.ID.String(),
 		},
-		Name:    u.Name,
-		Email:   u.Email,
-		Picture: gravatar.New(u.Email, nil),
+		Name:        u.Name,
+		Email:       u.Email,
+		Picture:     gravatar.New(u.Email, nil),
+		AccountType: "sandbox",
 	}
 
 	// Add the orgID to the claims

--- a/pkg/quarterdeck/projects.go
+++ b/pkg/quarterdeck/projects.go
@@ -202,6 +202,7 @@ func (s *Server) ProjectAccess(c *gin.Context) {
 		OrgID:       claims.OrgID,
 		ProjectID:   project.ProjectID.String(),
 		Permissions: make([]string, 0, 4),
+		AccountType: claims.AccountType,
 	}
 
 	// Add only the user permissions related to topics and metrics to these claims -- whatever

--- a/pkg/quarterdeck/tokens/claims.go
+++ b/pkg/quarterdeck/tokens/claims.go
@@ -15,6 +15,7 @@ type Claims struct {
 	OrgID       string   `json:"org,omitempty"`
 	ProjectID   string   `json:"project,omitempty"`
 	Permissions []string `json:"permissions,omitempty"`
+	AccountType string   `json:"account,omitempty"`
 }
 
 // HasPermission checks if the claims contain the specified permission.


### PR DESCRIPTION
### Scope of changes

Adds `account` to JWT claims from quarterdeck that are hardcoded to "sandbox". In a follow on story we'll update Quarterdeck to retrieve the account type from the database. 

Fixes SC-23018

### Type of change

- [x] new feature
- [ ] bug fix
- [ ] documentation
- [ ] testing
- [x] technical debt
- [ ] other (describe)

### Acceptance criteria

The sandbox claim enables the front-end to move forward with sandbox UI detection. 

### Definition of Done

- [ ] I have manually tested the change running it locally (having rebuilt all containers) or via unit tests 
- [ ] I have added unit and/or integration tests that cover my changes
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have updated the dependencies list if necessary (including updating yarn.lock and/or go.sum)
- [ ] I have recompiled and included new protocol buffers to reflect changes I made if necessary
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)
- [x] I have notified the reviewer via Shortcut or Slack that this is ready for review
- [ ] Front-end: Checked sm, md, lg screen resolutions for effective responsiveness
- [x] Backend-end: Documented service configuration changes or created related devops stories

### Reviewer(s) checklist

- [ ] Front-end: I've reviewed the Figma design and confirmed that changes match the spec.
- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] Are there any TODOs in this PR that should be turned into stories?

